### PR TITLE
1단계 - 페이먼츠(카드 추가)

### DIFF
--- a/app/src/main/java/nextstep/payments/MainActivity.kt
+++ b/app/src/main/java/nextstep/payments/MainActivity.kt
@@ -6,10 +6,8 @@ import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import nextstep.payments.ui.add.AddCardScreen
 import nextstep.payments.ui.theme.PaymentsTheme
 
 class MainActivity : ComponentActivity() {
@@ -22,25 +20,9 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    Greeting("Android")
+                    AddCardScreen({}, {})
                 }
             }
         }
-    }
-}
-
-@Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
-    )
-}
-
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    PaymentsTheme {
-        Greeting("Android")
     }
 }

--- a/app/src/main/java/nextstep/payments/ui/add/AddCardScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/add/AddCardScreen.kt
@@ -1,0 +1,129 @@
+package nextstep.payments.ui.add
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import nextstep.payments.R
+import nextstep.payments.ui.component.PaymentCard
+import nextstep.payments.ui.component.PaymentInputField
+
+@Composable
+fun AddCardScreen(
+    onBackClick: () -> Unit,
+    onAddCardClick: () -> Unit,
+) {
+    var cardNumber: String by remember { mutableStateOf("") }
+    var expirationDate: String by remember { mutableStateOf("") }
+    var ownerName: String by remember { mutableStateOf("") }
+    var cvcNumber: String by remember { mutableStateOf("") }
+    var password: String by remember { mutableStateOf("") }
+
+    Scaffold(
+        topBar = {
+            AddCardAppbar(
+                onBackClick = onBackClick,
+                onAddCardClick = onAddCardClick
+            )
+        }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .padding(innerPadding)
+                .fillMaxWidth()
+                .padding(15.dp)
+        ) {
+            PaymentCard(
+                modifier = Modifier
+                    .align(Alignment.CenterHorizontally)
+                    .padding(top = 12.dp)
+            )
+            PaymentInputField(
+                modifier = Modifier.fillMaxWidth(),
+                text = cardNumber,
+                onTextChange = { cardNumber = it },
+                label = stringResource(id = R.string.card_number_label),
+                hint = stringResource(id = R.string.card_number_hint)
+            )
+
+            PaymentInputField(
+                text = expirationDate,
+                onTextChange = { expirationDate = it },
+                label = stringResource(id = R.string.card_expiration_date_label),
+                hint = stringResource(id = R.string.card_expiration_date_hint)
+            )
+            PaymentInputField(
+                modifier = Modifier.fillMaxWidth(),
+                text = ownerName,
+                onTextChange = { ownerName = it },
+                label = stringResource(id = R.string.card_owner_name_label),
+                hint = stringResource(id = R.string.card_owner_name_hint)
+            )
+            PaymentInputField(
+                text = cvcNumber,
+                onTextChange = { cvcNumber = it },
+                label = stringResource(id = R.string.card_cvc_code_label),
+                hint = stringResource(id = R.string.card_cvc_code_hint),
+                visualTransformation = PasswordVisualTransformation()
+            )
+            PaymentInputField(
+                text = password,
+                onTextChange = { password = it },
+                label = stringResource(id = R.string.card_password_label),
+                hint = stringResource(id = R.string.card_password_hint),
+                visualTransformation = PasswordVisualTransformation()
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AddCardAppbar(
+    onBackClick: () -> Unit,
+    onAddCardClick: () -> Unit
+) {
+    TopAppBar(title = { Text(text = stringResource(id = R.string.add_card_title)) },
+        navigationIcon = {
+            IconButton(onClick = { onBackClick() }) {
+                Icon(
+                    imageVector = Icons.Filled.ArrowBack,
+                    contentDescription = stringResource(id = R.string.app_on_back_click)
+                )
+            }
+        },
+        actions = {
+            IconButton(onClick = { onAddCardClick() }) {
+                Icon(
+                    imageVector = Icons.Filled.Check,
+                    contentDescription = stringResource(id = R.string.add_card_title)
+                )
+            }
+        })
+
+}
+
+@Preview
+@Composable
+fun AddCardScreenPreview() {
+    AddCardScreen(onBackClick = {}, onAddCardClick = {})
+}

--- a/app/src/main/java/nextstep/payments/ui/add/AddCardScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/add/AddCardScreen.kt
@@ -3,6 +3,8 @@ package nextstep.payments.ui.add
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Check
@@ -53,6 +55,7 @@ fun AddCardScreen(
                 .padding(innerPadding)
                 .fillMaxWidth()
                 .padding(15.dp)
+                .verticalScroll(state = rememberScrollState())
         ) {
             PaymentCard(
                 modifier = Modifier

--- a/app/src/main/java/nextstep/payments/ui/add/AddCardScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/add/AddCardScreen.kt
@@ -24,6 +24,8 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import nextstep.payments.R
+import nextstep.payments.ui.component.CreditCardVisualTransformation
+import nextstep.payments.ui.component.ExpirationDateVisualTransformation
 import nextstep.payments.ui.component.PaymentCard
 import nextstep.payments.ui.component.PaymentInputField
 
@@ -62,14 +64,16 @@ fun AddCardScreen(
                 text = cardNumber,
                 onTextChange = { cardNumber = it },
                 label = stringResource(id = R.string.card_number_label),
-                hint = stringResource(id = R.string.card_number_hint)
+                hint = stringResource(id = R.string.card_number_hint),
+                visualTransformation = CreditCardVisualTransformation()
             )
 
             PaymentInputField(
                 text = expirationDate,
                 onTextChange = { expirationDate = it },
                 label = stringResource(id = R.string.card_expiration_date_label),
-                hint = stringResource(id = R.string.card_expiration_date_hint)
+                hint = stringResource(id = R.string.card_expiration_date_hint),
+                visualTransformation = ExpirationDateVisualTransformation()
             )
             PaymentInputField(
                 modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/nextstep/payments/ui/component/PaymentCard.kt
+++ b/app/src/main/java/nextstep/payments/ui/component/PaymentCard.kt
@@ -1,0 +1,58 @@
+package nextstep.payments.ui.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun PaymentCard(
+    modifier: Modifier = Modifier,
+    cardColor: Color = Color(0xFF333333)
+) {
+    Card(
+        colors = CardDefaults.cardColors(
+            containerColor = cardColor,
+        ),
+        elevation = CardDefaults.cardElevation(
+            defaultElevation = 4.dp
+        ),
+        modifier = modifier.size(width = 208.dp, height = 124.dp)
+    ) {
+        ChipBox(Modifier.padding(top = 44.dp, start = 14.dp))
+    }
+}
+
+@Composable
+fun ChipBox(
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .size(width = 40.dp, height = 26.dp)
+            .background(
+                color = Color(0xFFCBBA64),
+                shape = RoundedCornerShape(4.dp)
+            )
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+fun ChipBoxPreview() {
+    ChipBox()
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PaymentCardPreview() {
+    PaymentCard()
+}

--- a/app/src/main/java/nextstep/payments/ui/component/PaymentInputField.kt
+++ b/app/src/main/java/nextstep/payments/ui/component/PaymentInputField.kt
@@ -6,6 +6,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.input.OffsetMapping
+import androidx.compose.ui.text.input.TransformedText
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -33,6 +36,84 @@ fun PaymentInputField(
         singleLine = true,
         visualTransformation = visualTransformation
     )
+}
+
+class CreditCardVisualTransformation(
+    private val cardNumberSeparator: String = " – "
+) : VisualTransformation {
+    override fun filter(text: AnnotatedString): TransformedText {
+        return creditCardFilter(text, cardNumberSeparator)
+    }
+}
+
+class ExpirationDateVisualTransformation(
+    private val dateSeparator: String = " / "
+) : VisualTransformation {
+    override fun filter(text: AnnotatedString): TransformedText {
+        return expirationDateFilter(text, dateSeparator)
+    }
+}
+
+fun expirationDateFilter(
+    text: AnnotatedString,
+    dateSeparator: String = " / "
+): TransformedText {
+    val trimmed = text.text.take(4)
+    var out = ""
+
+    for (i in trimmed.indices) {
+        out += trimmed[i]
+        if (i == 1) out += dateSeparator
+    }
+
+    val creditCardOffsetTranslator = object : OffsetMapping {
+        override fun originalToTransformed(offset: Int): Int {
+            if (offset <= 1) return offset
+            if (offset <= 1 + dateSeparator.length) return offset + dateSeparator.length
+            return 4 + dateSeparator.length
+        }
+
+        override fun transformedToOriginal(offset: Int): Int {
+            if (offset <= 2) return offset
+            if (offset <= 2 + dateSeparator.length) return offset - dateSeparator.length
+            return 4
+        }
+    }
+
+    return TransformedText(AnnotatedString(out), creditCardOffsetTranslator)
+}
+
+fun creditCardFilter(
+    text: AnnotatedString,
+    cardNumberSeparator: String = " – "
+): TransformedText {
+
+    val trimmed = if (text.text.length >= 16) text.text.substring(0..15) else text.text
+    var out = ""
+    for (i in trimmed.indices) {
+        out += trimmed[i]
+        if (i % 4 == 3 && i != 15) out += cardNumberSeparator
+    }
+
+    val creditCardOffsetTranslator = object : OffsetMapping {
+        override fun originalToTransformed(offset: Int): Int {
+            if (offset <= 3) return offset
+            if (offset <= 7) return offset + cardNumberSeparator.length
+            if (offset <= 11) return offset + cardNumberSeparator.length * 2
+            if (offset <= 16) return offset + cardNumberSeparator.length * 3
+            return 16 + cardNumberSeparator.length * 3
+        }
+
+        override fun transformedToOriginal(offset: Int): Int {
+            if (offset <= 4) return offset
+            if (offset <= 9) return offset - cardNumberSeparator.length
+            if (offset <= 14) return offset - cardNumberSeparator.length * 2
+            if (offset <= 19) return offset - cardNumberSeparator.length * 3
+            return 16
+        }
+    }
+
+    return TransformedText(AnnotatedString(out), creditCardOffsetTranslator)
 }
 
 @Preview(showBackground = true)

--- a/app/src/main/java/nextstep/payments/ui/component/PaymentInputField.kt
+++ b/app/src/main/java/nextstep/payments/ui/component/PaymentInputField.kt
@@ -1,0 +1,47 @@
+package nextstep.payments.ui.component
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun PaymentInputField(
+    text: String,
+    onTextChange: (String) -> Unit,
+    label: String,
+    hint: String,
+    modifier: Modifier = Modifier,
+    maxLength: Int = Int.MAX_VALUE,
+    visualTransformation: VisualTransformation = VisualTransformation.None
+) {
+    OutlinedTextField(
+        value = text.take(maxLength),
+        onValueChange = { onTextChange(it) },
+        modifier = modifier.padding(top = 20.dp),
+        label = {
+            Text(text = label)
+        },
+        placeholder = {
+            Text(text = hint, color = Color.LightGray)
+        },
+        singleLine = true,
+        visualTransformation = visualTransformation
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+fun PaymentInputFieldPreview() {
+    PaymentInputField(
+        text = "test",
+        onTextChange = {},
+        label = "label",
+        hint = "hint"
+    )
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,18 @@
 <resources>
     <string name="app_name">Payments</string>
+    <string name="app_on_back_click">뒤로 가기</string>
+
+    <string name="add_card_title">카드 추가</string>
+
+    <string name="card_number_label">카드 번호</string>
+    <string name="card_expiration_date_label">만료일</string>
+    <string name="card_owner_name_label">카드 소유자 이름(선택)</string>
+    <string name="card_cvc_code_label">보안 코드(CVC/CVV)</string>
+    <string name="card_password_label">비밀번호</string>
+
+    <string name="card_number_hint">0000 – 0000 – 0000 – 0000</string>
+    <string name="card_expiration_date_hint">MM / YY</string>
+    <string name="card_owner_name_hint">카드에 표시된 이름을 입력하세요.</string>
+    <string name="card_cvc_code_hint">000</string>
+    <string name="card_password_hint">0000</string>
 </resources>


### PR DESCRIPTION
# 1단계 페이먼트 카드 추가 

### 기능 요구 사항
카드 추가 뷰을 구현한다.
보안 코드와 비밀번호는 노출되어서는 안 된다.
(선택사항) 카드 번호와 만료일의 경우 입력할 때 자동으로 기호(-, /)가 삽입된다.
(선택사항) 카드 소유자 이름의 경우 입력 글자 제한이 30자이다.
### 프로그래밍 요구 사항
실제로 카드 데이터가 추가되는 기능에 대해서는 이 단계에서 고민하지 않아도 된다.
OutlinedTextField를 활용한다.

---
글자 제한이 30자를 뺴먹었네요! 
해당 요구사항은 다음단계 진행하면서 만들어볼게요 :)
