### PR TITLE
2단계 - 페이먼츠(카드 목록)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -58,6 +58,7 @@ dependencies {
     implementation("androidx.compose.ui:ui-graphics")
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.material3:material3")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.7.0")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -59,6 +59,7 @@ dependencies {
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.compose.material3:material3")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.7.0")
+    implementation("androidx.navigation:navigation-compose:2.7.7")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")

--- a/app/src/androidTest/java/nextstep/payments/NavigationTest.kt
+++ b/app/src/androidTest/java/nextstep/payments/NavigationTest.kt
@@ -1,0 +1,77 @@
+package nextstep.payments
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.ComposeNavigator
+import androidx.navigation.compose.rememberNavController
+import nextstep.payments.ui.AppNavHost
+import nextstep.payments.ui.navigation.NavigationItem
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class NavigationTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+    private lateinit var navController: NavHostController
+
+    @Before
+    fun setupAppNavHost() {
+        composeTestRule.setContent {
+            navController = rememberNavController()
+            navController.navigatorProvider.addNavigator(ComposeNavigator())
+            AppNavHost(navHostController = navController)
+        }
+    }
+
+    @Test
+    fun 시작화면은_카드리스트_화면이다() {
+        val actual = navController.currentBackStackEntry?.destination?.route
+        assert(actual == NavigationItem.PaymentCards.route)
+    }
+
+    @Test
+    fun 카드리스트에서_추가버튼_클릭시_카드추가_화면으로_이동한다() {
+        // given
+        시작화면은_카드리스트_화면이다()
+        // when
+        composeTestRule
+            .onNodeWithContentDescription("추가")
+            .performClick()
+        val current = navController.currentBackStackEntry?.destination?.route
+
+        // then
+        composeTestRule
+            .onNodeWithText("카드 추가")
+            .assertExists()
+        assert(current == NavigationItem.AddCard.route)
+    }
+
+    @Test
+    fun 카드추가후_카드리스트_화면에서_추가된_카드가_보여진다() {
+
+        // given
+        카드리스트에서_추가버튼_클릭시_카드추가_화면으로_이동한다()
+
+        // when
+        composeTestRule
+            .onNodeWithText("카드 소유자 이름(선택)")
+            .performTextInput("카드소유자")
+        composeTestRule
+            .onNodeWithContentDescription("카드 추가")
+            .performClick()
+
+        // then
+        composeTestRule.runOnIdle {
+            val current = navController.currentBackStackEntry?.destination?.route
+            assert(current == NavigationItem.PaymentCards.route)
+        }
+        composeTestRule
+            .onNodeWithText("카드소유자")
+            .assertExists()
+    }
+}

--- a/app/src/androidTest/java/nextstep/payments/ui/NavigationTest.kt
+++ b/app/src/androidTest/java/nextstep/payments/ui/NavigationTest.kt
@@ -1,4 +1,4 @@
-package nextstep.payments
+package nextstep.payments.ui
 
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
@@ -8,7 +8,6 @@ import androidx.compose.ui.test.performTextInput
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.ComposeNavigator
 import androidx.navigation.compose.rememberNavController
-import nextstep.payments.ui.AppNavHost
 import nextstep.payments.ui.navigation.NavigationItem
 import org.junit.Before
 import org.junit.Rule
@@ -55,12 +54,13 @@ class NavigationTest {
     fun 카드추가후_카드리스트_화면에서_추가된_카드가_보여진다() {
 
         // given
+        val ownerName = "남잭슨"
         카드리스트에서_추가버튼_클릭시_카드추가_화면으로_이동한다()
 
         // when
         composeTestRule
             .onNodeWithText("카드 소유자 이름(선택)")
-            .performTextInput("카드소유자")
+            .performTextInput(ownerName)
         composeTestRule
             .onNodeWithContentDescription("카드 추가")
             .performClick()
@@ -71,7 +71,7 @@ class NavigationTest {
             assert(current == NavigationItem.PaymentCards.route)
         }
         composeTestRule
-            .onNodeWithText("카드소유자")
+            .onNodeWithText(ownerName)
             .assertExists()
     }
 }

--- a/app/src/androidTest/java/nextstep/payments/ui/payments/PaymentsCardsScreenTest.kt
+++ b/app/src/androidTest/java/nextstep/payments/ui/payments/PaymentsCardsScreenTest.kt
@@ -1,0 +1,86 @@
+package nextstep.payments.ui.payments
+
+import androidx.annotation.StringRes
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.platform.app.InstrumentationRegistry
+import nextstep.payments.R
+import org.junit.Rule
+import org.junit.Test
+
+class PaymentsCardsScreenTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun 카드가_없을때_카드추가타이틀과_추가카드가_보여야한다() {
+        // Given
+        val uiState = PaymentCardsUiState.Empty
+
+        // When
+        composeTestRule.setContent {
+            PaymentCardsScreen(uiState = uiState, onAddCardClick = {})
+        }
+
+        // Then
+        composeTestRule.onNodeWithText(getString(R.string.payments_add_card_title))
+            .assertIsDisplayed()
+
+        composeTestRule.onNodeWithTag("AddCard")
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun 카드가_1장일때_카드한장과_추가카드가_보여야한다() {
+        // Given
+        val card = mockPaymentCard()
+        val uiState = PaymentCardsUiState.One(card)
+
+        // When
+        composeTestRule.setContent {
+            PaymentCardsScreen(uiState = uiState, onAddCardClick = {})
+        }
+
+        // Then
+        composeTestRule.onNodeWithTag("PaymentCard")
+            .assertIsDisplayed()
+        composeTestRule.onNodeWithText(card.ownerName)
+            .assertIsDisplayed()
+        composeTestRule.onAllNodesWithTag("PaymentCard")
+            .assertCountEquals(1)
+
+        composeTestRule.onNodeWithTag("AddCard")
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun 카드가_여러장일때_카드들이_보여아한다() {
+        // Given
+        val cards = listOf(mockPaymentCard(), mockPaymentCard(), mockPaymentCard())
+        val uiState = PaymentCardsUiState.Many(cards)
+
+        // When
+        composeTestRule.setContent {
+            PaymentCardsScreen(uiState = uiState, onAddCardClick = {})
+        }
+
+        // Then
+        composeTestRule.onAllNodesWithTag("PaymentCard")
+            .assertCountEquals(cards.size)
+
+        composeTestRule.onNodeWithText(getString(R.string.payments_add_card))
+            .assertIsDisplayed()
+        composeTestRule.onNodeWithTag("AddCard")
+            .assertDoesNotExist()
+    }
+
+    private fun getString(@StringRes id: Int): String {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        return context.resources.getString(id)
+    }
+}

--- a/app/src/main/java/nextstep/payments/MainActivity.kt
+++ b/app/src/main/java/nextstep/payments/MainActivity.kt
@@ -7,7 +7,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
-import nextstep.payments.ui.add.AddCardScreen
+import androidx.navigation.compose.rememberNavController
+import nextstep.payments.ui.AppNavHost
 import nextstep.payments.ui.theme.PaymentsTheme
 
 class MainActivity : ComponentActivity() {
@@ -20,7 +21,7 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    AddCardScreen({}, {})
+                    AppNavHost(navHostController = rememberNavController())
                 }
             }
         }

--- a/app/src/main/java/nextstep/payments/data/CachedPaymentRepository.kt
+++ b/app/src/main/java/nextstep/payments/data/CachedPaymentRepository.kt
@@ -1,0 +1,15 @@
+package nextstep.payments.data
+
+import nextstep.payments.domain.PaymentCard
+import nextstep.payments.domain.PaymentRepository
+
+object CachedPaymentRepository : PaymentRepository {
+    private val cachedPayment = mutableListOf<PaymentCard>()
+    override suspend fun addPaymentCard(payment: PaymentCard) {
+        cachedPayment.add(payment)
+    }
+
+    override suspend fun getPayments(): List<PaymentCard> {
+        return cachedPayment
+    }
+}

--- a/app/src/main/java/nextstep/payments/data/CachedPaymentRepository.kt
+++ b/app/src/main/java/nextstep/payments/data/CachedPaymentRepository.kt
@@ -5,8 +5,9 @@ import nextstep.payments.domain.PaymentRepository
 
 object CachedPaymentRepository : PaymentRepository {
     private val cachedPayment = mutableListOf<PaymentCard>()
-    override suspend fun addPaymentCard(payment: PaymentCard) {
+    override suspend fun addPaymentCard(payment: PaymentCard): String {
         cachedPayment.add(payment)
+        return payment.id
     }
 
     override suspend fun getPayments(): List<PaymentCard> {

--- a/app/src/main/java/nextstep/payments/domain/PaymentCard.kt
+++ b/app/src/main/java/nextstep/payments/domain/PaymentCard.kt
@@ -1,0 +1,21 @@
+package nextstep.payments.domain
+
+data class PaymentCard(
+    val id: String,
+    val cardNumber: String,
+    val ownerName: String,
+    val expirationDate: String,
+    val cvcNumber: String,
+    val password: String
+) {
+    companion object {
+        val MockData = PaymentCard(
+            id = "1",
+            cardNumber = "1111222233334444",
+            ownerName = "Namjackson",
+            expirationDate = "0425",
+            cvcNumber = "123",
+            password = "1234"
+        )
+    }
+}

--- a/app/src/main/java/nextstep/payments/domain/PaymentCard.kt
+++ b/app/src/main/java/nextstep/payments/domain/PaymentCard.kt
@@ -7,15 +7,4 @@ data class PaymentCard(
     val expirationDate: String,
     val cvcNumber: String,
     val password: String
-) {
-    companion object {
-        val MockData = PaymentCard(
-            id = "1",
-            cardNumber = "1111222233334444",
-            ownerName = "Namjackson",
-            expirationDate = "0425",
-            cvcNumber = "123",
-            password = "1234"
-        )
-    }
-}
+)

--- a/app/src/main/java/nextstep/payments/domain/PaymentRepository.kt
+++ b/app/src/main/java/nextstep/payments/domain/PaymentRepository.kt
@@ -1,6 +1,6 @@
 package nextstep.payments.domain
 
 interface PaymentRepository {
-    suspend fun addPaymentCard(payment: PaymentCard)
+    suspend fun addPaymentCard(payment: PaymentCard): String
     suspend fun getPayments(): List<PaymentCard>
 }

--- a/app/src/main/java/nextstep/payments/domain/PaymentRepository.kt
+++ b/app/src/main/java/nextstep/payments/domain/PaymentRepository.kt
@@ -1,0 +1,6 @@
+package nextstep.payments.domain
+
+interface PaymentRepository {
+    suspend fun addPaymentCard(payment: PaymentCard)
+    suspend fun getPayments(): List<PaymentCard>
+}

--- a/app/src/main/java/nextstep/payments/ui/AppNavHost.kt
+++ b/app/src/main/java/nextstep/payments/ui/AppNavHost.kt
@@ -1,0 +1,32 @@
+package nextstep.payments.ui
+
+import androidx.compose.runtime.Composable
+import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import nextstep.payments.ui.add.AddCardScreenRoute
+import nextstep.payments.ui.navigation.NavigationItem
+import nextstep.payments.ui.payments.PaymentCardsScreenRoute
+
+@Composable
+fun AppNavHost(
+    navHostController: NavHostController
+) {
+    NavHost(
+        navController = navHostController,
+        startDestination = NavigationItem.PaymentCards.route
+    ) {
+        composable(NavigationItem.PaymentCards.route) {
+            PaymentCardsScreenRoute(
+                onAddCardClick = { navHostController.navigate(NavigationItem.AddCard.route) }
+            )
+        }
+        composable(NavigationItem.AddCard.route) {
+            AddCardScreenRoute(
+                onBackClick = { navHostController.popBackStack() },
+                onBackWithAddCompleted = { navHostController.popBackStack() }
+            )
+        }
+    }
+}

--- a/app/src/main/java/nextstep/payments/ui/AppNavHost.kt
+++ b/app/src/main/java/nextstep/payments/ui/AppNavHost.kt
@@ -1,7 +1,6 @@
 package nextstep.payments.ui
 
 import androidx.compose.runtime.Composable
-import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -17,15 +16,22 @@ fun AppNavHost(
         navController = navHostController,
         startDestination = NavigationItem.PaymentCards.route
     ) {
-        composable(NavigationItem.PaymentCards.route) {
+        composable(NavigationItem.PaymentCards.route) { navBackResult ->
+            val newId = navBackResult.savedStateHandle.remove<String>("newPaymentId") ?: ""
             PaymentCardsScreenRoute(
-                onAddCardClick = { navHostController.navigate(NavigationItem.AddCard.route) }
+                onAddCardClick = { navHostController.navigate(NavigationItem.AddCard.route) },
+                newCardId = newId
             )
         }
         composable(NavigationItem.AddCard.route) {
             AddCardScreenRoute(
                 onBackClick = { navHostController.popBackStack() },
-                onBackWithAddCompleted = { navHostController.popBackStack() }
+                onBackWithAddCompleted = { newPaymentId ->
+                    navHostController.previousBackStackEntry
+                        ?.savedStateHandle
+                        ?.set("newPaymentId", newPaymentId)
+                    navHostController.popBackStack()
+                }
             )
         }
     }

--- a/app/src/main/java/nextstep/payments/ui/add/AddCardScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/add/AddCardScreen.kt
@@ -16,11 +16,9 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -33,16 +31,21 @@ import nextstep.payments.R
 import nextstep.payments.ui.component.CreditCardVisualTransformation
 import nextstep.payments.ui.component.EmptyPaymentCard
 import nextstep.payments.ui.component.ExpirationDateVisualTransformation
-import nextstep.payments.ui.component.PaymentCard
 import nextstep.payments.ui.component.PaymentInputField
 
 @Composable
 fun AddCardScreenRoute(
     onBackClick: () -> Unit,
-    onBackWithAddCompleted: () -> Unit,
+    onBackWithAddCompleted: (String) -> Unit,
     viewModel: AddCardViewModel = viewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
+    val addCompleted by viewModel.addCompleted.collectAsState()
+    LaunchedEffect(key1 = addCompleted, block = {
+        if (addCompleted.isNotEmpty()) {
+            onBackWithAddCompleted(addCompleted)
+        }
+    })
     AddCardScreen(
         uiState = uiState,
         onCardNumberChange = { viewModel.updateCardNumber(it) },
@@ -53,7 +56,6 @@ fun AddCardScreenRoute(
         onBackClick = onBackClick,
         onAddCardClick = {
             viewModel.addPayment()
-            onBackWithAddCompleted()
         },
     )
 }

--- a/app/src/main/java/nextstep/payments/ui/add/AddCardScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/add/AddCardScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
@@ -15,6 +16,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -22,25 +24,51 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import nextstep.payments.R
 import nextstep.payments.ui.component.CreditCardVisualTransformation
+import nextstep.payments.ui.component.EmptyPaymentCard
 import nextstep.payments.ui.component.ExpirationDateVisualTransformation
 import nextstep.payments.ui.component.PaymentCard
 import nextstep.payments.ui.component.PaymentInputField
 
 @Composable
-fun AddCardScreen(
+fun AddCardScreenRoute(
+    onBackClick: () -> Unit,
+    onBackWithAddCompleted: () -> Unit,
+    viewModel: AddCardViewModel = viewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    AddCardScreen(
+        uiState = uiState,
+        onCardNumberChange = { viewModel.updateCardNumber(it) },
+        onExpirationDateChange = { viewModel.updateExpirationDate(it) },
+        onOwnerNameChange = { viewModel.updateOwnerName(it) },
+        onCvcNumberChange = { viewModel.updateCvcNumber(it) },
+        onPasswordChange = { viewModel.updatePassword(it) },
+        onBackClick = onBackClick,
+        onAddCardClick = {
+            viewModel.addPayment()
+            onBackWithAddCompleted()
+        },
+    )
+}
+
+@Composable
+private fun AddCardScreen(
+    uiState: AddCardUiState,
+    onCardNumberChange: (String) -> Unit,
+    onExpirationDateChange: (String) -> Unit,
+    onOwnerNameChange: (String) -> Unit,
+    onCvcNumberChange: (String) -> Unit,
+    onPasswordChange: (String) -> Unit,
     onBackClick: () -> Unit,
     onAddCardClick: () -> Unit,
 ) {
-    var cardNumber: String by remember { mutableStateOf("") }
-    var expirationDate: String by remember { mutableStateOf("") }
-    var ownerName: String by remember { mutableStateOf("") }
-    var cvcNumber: String by remember { mutableStateOf("") }
-    var password: String by remember { mutableStateOf("") }
 
     Scaffold(
         topBar = {
@@ -57,47 +85,51 @@ fun AddCardScreen(
                 .padding(15.dp)
                 .verticalScroll(state = rememberScrollState())
         ) {
-            PaymentCard(
+            EmptyPaymentCard(
                 modifier = Modifier
                     .align(Alignment.CenterHorizontally)
                     .padding(top = 12.dp)
             )
             PaymentInputField(
                 modifier = Modifier.fillMaxWidth(),
-                text = cardNumber,
-                onTextChange = { cardNumber = it },
+                text = uiState.cardNumber,
+                onTextChange = { onCardNumberChange(it) },
                 label = stringResource(id = R.string.card_number_label),
                 hint = stringResource(id = R.string.card_number_hint),
-                visualTransformation = CreditCardVisualTransformation()
+                visualTransformation = CreditCardVisualTransformation(),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
             )
 
             PaymentInputField(
-                text = expirationDate,
-                onTextChange = { expirationDate = it },
+                text = uiState.expirationDate,
+                onTextChange = { onExpirationDateChange(it) },
                 label = stringResource(id = R.string.card_expiration_date_label),
                 hint = stringResource(id = R.string.card_expiration_date_hint),
-                visualTransformation = ExpirationDateVisualTransformation()
+                visualTransformation = ExpirationDateVisualTransformation(),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
             )
             PaymentInputField(
                 modifier = Modifier.fillMaxWidth(),
-                text = ownerName,
-                onTextChange = { ownerName = it },
+                text = uiState.ownerName,
+                onTextChange = { onOwnerNameChange(it) },
                 label = stringResource(id = R.string.card_owner_name_label),
                 hint = stringResource(id = R.string.card_owner_name_hint)
             )
             PaymentInputField(
-                text = cvcNumber,
-                onTextChange = { cvcNumber = it },
+                text = uiState.cvcNumber,
+                onTextChange = { onCvcNumberChange(it) },
                 label = stringResource(id = R.string.card_cvc_code_label),
                 hint = stringResource(id = R.string.card_cvc_code_hint),
-                visualTransformation = PasswordVisualTransformation()
+                visualTransformation = PasswordVisualTransformation(),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
             )
             PaymentInputField(
-                text = password,
-                onTextChange = { password = it },
+                text = uiState.password,
+                onTextChange = { onPasswordChange(it) },
                 label = stringResource(id = R.string.card_password_label),
                 hint = stringResource(id = R.string.card_password_hint),
-                visualTransformation = PasswordVisualTransformation()
+                visualTransformation = PasswordVisualTransformation(),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
             )
         }
     }
@@ -105,7 +137,7 @@ fun AddCardScreen(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun AddCardAppbar(
+private fun AddCardAppbar(
     onBackClick: () -> Unit,
     onAddCardClick: () -> Unit
 ) {
@@ -131,6 +163,8 @@ fun AddCardAppbar(
 
 @Preview
 @Composable
-fun AddCardScreenPreview() {
-    AddCardScreen(onBackClick = {}, onAddCardClick = {})
+private fun AddCardScreenPreview() {
+    AddCardScreen(
+        uiState = AddCardUiState(), {}, {}, {}, {}, {}, {}, {}
+    )
 }

--- a/app/src/main/java/nextstep/payments/ui/add/AddCardUiState.kt
+++ b/app/src/main/java/nextstep/payments/ui/add/AddCardUiState.kt
@@ -1,0 +1,23 @@
+package nextstep.payments.ui.add
+
+import nextstep.payments.domain.PaymentCard
+import java.util.UUID
+
+data class AddCardUiState(
+    val cardNumber: String = "",
+    val ownerName: String = "",
+    val expirationDate: String = "",
+    val cvcNumber: String = "",
+    val password: String = "",
+) {
+    companion object {
+        fun AddCardUiState.toPaymentCard(): PaymentCard = PaymentCard(
+            UUID.randomUUID().toString(),
+            cardNumber,
+            ownerName,
+            expirationDate,
+            cvcNumber,
+            password
+        )
+    }
+}

--- a/app/src/main/java/nextstep/payments/ui/add/AddCardViewModel.kt
+++ b/app/src/main/java/nextstep/payments/ui/add/AddCardViewModel.kt
@@ -1,0 +1,45 @@
+package nextstep.payments.ui.add
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import nextstep.payments.data.CachedPaymentRepository
+import nextstep.payments.domain.PaymentRepository
+import nextstep.payments.ui.add.AddCardUiState.Companion.toPaymentCard
+
+class AddCardViewModel(
+    private val paymentRepository: PaymentRepository = CachedPaymentRepository
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(AddCardUiState())
+    val uiState: StateFlow<AddCardUiState> = _uiState.asStateFlow()
+
+    fun addPayment() {
+        viewModelScope.launch {
+            paymentRepository.addPaymentCard(uiState.value.toPaymentCard())
+        }
+    }
+
+    fun updateCardNumber(cardNumber: String) {
+        _uiState.value = uiState.value.copy(cardNumber = cardNumber)
+    }
+
+    fun updateExpirationDate(expirationDate: String) {
+        _uiState.value = uiState.value.copy(expirationDate = expirationDate)
+    }
+
+    fun updateOwnerName(ownerName: String) {
+        _uiState.value = uiState.value.copy(ownerName = ownerName)
+    }
+
+    fun updateCvcNumber(cvcNumber: String) {
+        _uiState.value = uiState.value.copy(cvcNumber = cvcNumber)
+    }
+
+    fun updatePassword(password: String) {
+        _uiState.value = uiState.value.copy(password = password)
+    }
+}

--- a/app/src/main/java/nextstep/payments/ui/add/AddCardViewModel.kt
+++ b/app/src/main/java/nextstep/payments/ui/add/AddCardViewModel.kt
@@ -17,9 +17,13 @@ class AddCardViewModel(
     private val _uiState = MutableStateFlow(AddCardUiState())
     val uiState: StateFlow<AddCardUiState> = _uiState.asStateFlow()
 
+    private val _addCompleted = MutableStateFlow("")
+    val addCompleted: StateFlow<String> = _addCompleted.asStateFlow()
+
     fun addPayment() {
         viewModelScope.launch {
             paymentRepository.addPaymentCard(uiState.value.toPaymentCard())
+                .also { newPaymentId -> _addCompleted.value = newPaymentId }
         }
     }
 

--- a/app/src/main/java/nextstep/payments/ui/component/PaymentCard.kt
+++ b/app/src/main/java/nextstep/payments/ui/component/PaymentCard.kt
@@ -1,38 +1,151 @@
 package nextstep.payments.ui.component
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import nextstep.payments.domain.PaymentCard
 
 @Composable
-fun PaymentCard(
+fun EmptyPaymentCard(
     modifier: Modifier = Modifier,
     cardColor: Color = Color(0xFF333333)
 ) {
+    PaymentCardLayout(
+        modifier = modifier,
+        cardColor = cardColor,
+        content = {
+            ChipBox(Modifier.padding(top = 44.dp, start = 14.dp))
+        }
+    )
+}
+
+@Composable
+fun PaymentCard(
+    payment: PaymentCard,
+    modifier: Modifier = Modifier,
+    cardColor: Color = Color(0xFF333333)
+) {
+    PaymentCardLayout(
+        modifier = modifier,
+        cardColor = cardColor,
+        content = {
+            Column(
+                Modifier
+                    .fillMaxSize()
+                    .padding(start = 14.dp, end = 14.dp, top = 44.dp, bottom = 16.dp),
+                verticalArrangement = Arrangement.SpaceBetween
+            ) {
+                ChipBox()
+                MaskedCardNumber(
+                    modifier = Modifier.fillMaxWidth(),
+                    cardNumber = payment.cardNumber
+                )
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text(
+                        text = payment.ownerName,
+                        color = Color.White,
+                        fontSize = 12.sp
+                    )
+                    FormattedDateText(text = payment.expirationDate)
+                }
+            }
+        }
+    )
+}
+
+@Composable
+private fun MaskedCardNumber(
+    cardNumber: String,
+    modifier: Modifier = Modifier
+) {
+    val maskedCardNumber = cardNumber.take(8) + "*".repeat(8)
+    val formattedText = creditCardFilter(AnnotatedString(maskedCardNumber)).text
+    Text(
+        modifier = modifier.fillMaxWidth(),
+        text = formattedText,
+        fontSize = 12.sp,
+        color = Color.White,
+        maxLines = 1
+    )
+}
+
+@Composable
+private fun FormattedDateText(
+    text: String,
+    modifier: Modifier = Modifier
+) {
+    val formattedText = expirationDateFilter(AnnotatedString(text)).text
+    Text(
+        modifier = modifier,
+        text = formattedText,
+        fontSize = 12.sp,
+        color = Color.White,
+    )
+}
+
+@Composable
+fun AddCard(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    PaymentCardLayout(
+        modifier = modifier,
+        cardColor = Color(0xFFE5E5E5),
+        content = {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .clickable { onClick() },
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(imageVector = Icons.Default.Add, contentDescription = "")
+            }
+        }
+    )
+}
+
+@Composable
+private fun PaymentCardLayout(
+    modifier: Modifier = Modifier,
+    cardColor: Color,
+    content: @Composable () -> Unit = {}
+) {
     Card(
-        colors = CardDefaults.cardColors(
-            containerColor = cardColor,
-        ),
-        elevation = CardDefaults.cardElevation(
-            defaultElevation = 4.dp
-        ),
-        modifier = modifier.size(width = 208.dp, height = 124.dp)
+        modifier = modifier.size(width = 208.dp, height = 124.dp),
+        colors = CardDefaults.cardColors(containerColor = cardColor),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
     ) {
-        ChipBox(Modifier.padding(top = 44.dp, start = 14.dp))
+        content()
     }
 }
 
 @Composable
-fun ChipBox(
+private fun ChipBox(
     modifier: Modifier = Modifier
 ) {
     Box(
@@ -47,12 +160,24 @@ fun ChipBox(
 
 @Preview(showBackground = true)
 @Composable
-fun ChipBoxPreview() {
+private fun ChipBoxPreview() {
     ChipBox()
 }
 
 @Preview(showBackground = true)
 @Composable
-fun PaymentCardPreview() {
-    PaymentCard()
+private fun EmptyPaymentCardPreview() {
+    EmptyPaymentCard()
+}
+
+@Preview
+@Composable
+fun AddCardPreview() {
+    AddCard({})
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PaymentCardPreview() {
+    PaymentCard(payment = PaymentCard.MockData)
 }

--- a/app/src/main/java/nextstep/payments/ui/component/PaymentCard.kt
+++ b/app/src/main/java/nextstep/payments/ui/component/PaymentCard.kt
@@ -21,10 +21,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import nextstep.payments.R
 import nextstep.payments.domain.PaymentCard
 
 @Composable
@@ -123,7 +125,7 @@ fun AddCard(
                     .clickable { onClick() },
                 contentAlignment = Alignment.Center
             ) {
-                Icon(imageVector = Icons.Default.Add, contentDescription = "")
+                Icon(imageVector = Icons.Default.Add, contentDescription = stringResource(id = R.string.payments_add_card))
             }
         }
     )

--- a/app/src/main/java/nextstep/payments/ui/component/PaymentCard.kt
+++ b/app/src/main/java/nextstep/payments/ui/component/PaymentCard.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.tooling.preview.Preview
@@ -28,6 +29,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import nextstep.payments.R
 import nextstep.payments.domain.PaymentCard
+import nextstep.payments.ui.payments.mockPaymentCard
 
 @Composable
 fun EmptyPaymentCard(
@@ -50,7 +52,7 @@ fun PaymentCard(
     cardColor: Color = Color(0xFF333333)
 ) {
     PaymentCardLayout(
-        modifier = modifier,
+        modifier = modifier.testTag("PaymentCard"),
         cardColor = cardColor,
         content = {
             Column(
@@ -116,7 +118,7 @@ fun AddCard(
     modifier: Modifier = Modifier
 ) {
     PaymentCardLayout(
-        modifier = modifier,
+        modifier = modifier.testTag("AddCard"),
         cardColor = Color(0xFFE5E5E5),
         content = {
             Box(
@@ -181,5 +183,5 @@ fun AddCardPreview() {
 @Preview(showBackground = true)
 @Composable
 private fun PaymentCardPreview() {
-    PaymentCard(payment = PaymentCard.MockData)
+    PaymentCard(payment = mockPaymentCard())
 }

--- a/app/src/main/java/nextstep/payments/ui/component/PaymentInputField.kt
+++ b/app/src/main/java/nextstep/payments/ui/component/PaymentInputField.kt
@@ -1,6 +1,7 @@
 package nextstep.payments.ui.component
 
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -21,7 +22,8 @@ fun PaymentInputField(
     hint: String,
     modifier: Modifier = Modifier,
     maxLength: Int = Int.MAX_VALUE,
-    visualTransformation: VisualTransformation = VisualTransformation.None
+    visualTransformation: VisualTransformation = VisualTransformation.None,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default
 ) {
     OutlinedTextField(
         value = text.take(maxLength),
@@ -34,7 +36,8 @@ fun PaymentInputField(
             Text(text = hint, color = Color.LightGray)
         },
         singleLine = true,
-        visualTransformation = visualTransformation
+        visualTransformation = visualTransformation,
+        keyboardOptions = keyboardOptions
     )
 }
 

--- a/app/src/main/java/nextstep/payments/ui/navigation/NavigationItem.kt
+++ b/app/src/main/java/nextstep/payments/ui/navigation/NavigationItem.kt
@@ -1,0 +1,9 @@
+package nextstep.payments.ui.navigation
+
+sealed class NavigationItem(val route: String) {
+
+    data object PaymentCards : NavigationItem("PaymentCards")
+
+    data object AddCard : NavigationItem("AddCard")
+
+}

--- a/app/src/main/java/nextstep/payments/ui/payments/PaymentCardsScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/payments/PaymentCardsScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -23,8 +24,14 @@ import nextstep.payments.ui.payments.component.PaymentCardList
 @Composable
 fun PaymentCardsScreenRoute(
     onAddCardClick: () -> Unit,
+    newCardId: String,
     viewModel: PaymentCardsViewModel = viewModel(),
 ) {
+    LaunchedEffect(key1 = newCardId, block = {
+        if (newCardId.isNotEmpty()) {
+            viewModel.loadCardPayments()
+        }
+    })
     val uiState by viewModel.uiState.collectAsState()
     PaymentCardsScreen(
         uiState = uiState,

--- a/app/src/main/java/nextstep/payments/ui/payments/PaymentCardsScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/payments/PaymentCardsScreen.kt
@@ -1,0 +1,78 @@
+package nextstep.payments.ui.payments
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.sp
+import nextstep.payments.R
+import nextstep.payments.domain.PaymentCard
+import nextstep.payments.ui.payments.component.PaymentCardList
+
+@Composable
+fun PaymentCardsScreenRoute(
+    onAddCardClick: () -> Unit
+) {
+    PaymentCardsScreen(
+        uiState = PaymentCardsUiState.One(PaymentCard.MockData),
+        onAddCardClick = onAddCardClick
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun PaymentCardsScreen(
+    uiState: PaymentCardsUiState,
+    onAddCardClick: () -> Unit
+) {
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = {
+                    Text(
+                        text = stringResource(id = R.string.payments_title),
+                        fontSize = 22.sp
+                    )
+                },
+                actions = {
+                    if (uiState is PaymentCardsUiState.Many) {
+                        TextButton(onClick = { onAddCardClick() }) {
+                            Text(
+                                text = stringResource(id = R.string.payments_add_card),
+                                color = Color.Black,
+                                fontSize = 18.sp,
+                                fontWeight = FontWeight.Bold
+                            )
+                        }
+                    }
+                },
+            )
+        }
+    ) { innerPadding ->
+        PaymentCardList(
+            modifier = Modifier.padding(innerPadding),
+            onAddCardClick = onAddCardClick,
+            uiState = uiState
+        )
+    }
+}
+
+@Preview
+@Composable
+fun PaymentCardsScreenPreview(
+    @PreviewParameter(PaymentCardsUiStatePreviewParameterProvider::class) paymentCardsUiState: PaymentCardsUiState
+) {
+    PaymentCardsScreen(
+        uiState = paymentCardsUiState,
+        onAddCardClick = {}
+    )
+}

--- a/app/src/main/java/nextstep/payments/ui/payments/PaymentCardsScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/payments/PaymentCardsScreen.kt
@@ -41,7 +41,7 @@ fun PaymentCardsScreenRoute(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun PaymentCardsScreen(
+internal fun PaymentCardsScreen(
     uiState: PaymentCardsUiState,
     onAddCardClick: () -> Unit
 ) {

--- a/app/src/main/java/nextstep/payments/ui/payments/PaymentCardsScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/payments/PaymentCardsScreen.kt
@@ -7,6 +7,8 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
@@ -14,16 +16,18 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import nextstep.payments.R
-import nextstep.payments.domain.PaymentCard
 import nextstep.payments.ui.payments.component.PaymentCardList
 
 @Composable
 fun PaymentCardsScreenRoute(
-    onAddCardClick: () -> Unit
+    onAddCardClick: () -> Unit,
+    viewModel: PaymentCardsViewModel = viewModel(),
 ) {
+    val uiState by viewModel.uiState.collectAsState()
     PaymentCardsScreen(
-        uiState = PaymentCardsUiState.One(PaymentCard.MockData),
+        uiState = uiState,
         onAddCardClick = onAddCardClick
     )
 }

--- a/app/src/main/java/nextstep/payments/ui/payments/PaymentCardsUiState.kt
+++ b/app/src/main/java/nextstep/payments/ui/payments/PaymentCardsUiState.kt
@@ -7,20 +7,48 @@ sealed interface PaymentCardsUiState {
     data object Empty : PaymentCardsUiState
     data class One(val card: PaymentCard) : PaymentCardsUiState
     data class Many(val cards: List<PaymentCard>) : PaymentCardsUiState
+
+    companion object {
+        fun from(cards: List<PaymentCard>): PaymentCardsUiState {
+            return when {
+                cards.isEmpty() -> Empty
+                cards.size == 1 -> One(cards.first())
+                else -> Many(cards)
+            }
+        }
+    }
 }
 
 internal class PaymentCardsUiStatePreviewParameterProvider :
     PreviewParameterProvider<PaymentCardsUiState> {
     override val values = sequenceOf(
         PaymentCardsUiState.Empty,
-        PaymentCardsUiState.One(PaymentCard.MockData),
+        PaymentCardsUiState.One(mockPaymentCard()),
         PaymentCardsUiState.Many(
             cards = listOf(
-                PaymentCard.MockData,
-                PaymentCard.MockData,
-                PaymentCard.MockData,
-                PaymentCard.MockData
+                mockPaymentCard(),
+                mockPaymentCard(),
+                mockPaymentCard(),
+                mockPaymentCard(),
             )
         )
+    )
+}
+
+internal fun mockPaymentCard(
+    id: String = "1",
+    cardNumber: String = "1111222233334444",
+    ownerName: String = "Namjackson",
+    expirationDate: String = "0425",
+    cvcNumber: String = "123",
+    password: String = "1234"
+): PaymentCard {
+    return PaymentCard(
+        id = id,
+        cardNumber = cardNumber,
+        ownerName = ownerName,
+        expirationDate = expirationDate,
+        cvcNumber = cvcNumber,
+        password = password
     )
 }

--- a/app/src/main/java/nextstep/payments/ui/payments/PaymentCardsUiState.kt
+++ b/app/src/main/java/nextstep/payments/ui/payments/PaymentCardsUiState.kt
@@ -1,9 +1,26 @@
 package nextstep.payments.ui.payments
 
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import nextstep.payments.domain.PaymentCard
 
 sealed interface PaymentCardsUiState {
     data object Empty : PaymentCardsUiState
     data class One(val card: PaymentCard) : PaymentCardsUiState
     data class Many(val cards: List<PaymentCard>) : PaymentCardsUiState
+}
+
+internal class PaymentCardsUiStatePreviewParameterProvider :
+    PreviewParameterProvider<PaymentCardsUiState> {
+    override val values = sequenceOf(
+        PaymentCardsUiState.Empty,
+        PaymentCardsUiState.One(PaymentCard.MockData),
+        PaymentCardsUiState.Many(
+            cards = listOf(
+                PaymentCard.MockData,
+                PaymentCard.MockData,
+                PaymentCard.MockData,
+                PaymentCard.MockData
+            )
+        )
+    )
 }

--- a/app/src/main/java/nextstep/payments/ui/payments/PaymentCardsUiState.kt
+++ b/app/src/main/java/nextstep/payments/ui/payments/PaymentCardsUiState.kt
@@ -1,0 +1,9 @@
+package nextstep.payments.ui.payments
+
+import nextstep.payments.domain.PaymentCard
+
+sealed interface PaymentCardsUiState {
+    data object Empty : PaymentCardsUiState
+    data class One(val card: PaymentCard) : PaymentCardsUiState
+    data class Many(val cards: List<PaymentCard>) : PaymentCardsUiState
+}

--- a/app/src/main/java/nextstep/payments/ui/payments/PaymentCardsViewModel.kt
+++ b/app/src/main/java/nextstep/payments/ui/payments/PaymentCardsViewModel.kt
@@ -7,7 +7,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import nextstep.payments.data.CachedPaymentRepository
-import nextstep.payments.domain.PaymentCard
 import nextstep.payments.domain.PaymentRepository
 
 class PaymentCardsViewModel(
@@ -23,13 +22,8 @@ class PaymentCardsViewModel(
 
     fun loadCardPayments() {
         viewModelScope.launch {
-            _uiState.value = paymentRepository.getPayments().toUiState()
+            val cards = paymentRepository.getPayments()
+            _uiState.value = PaymentCardsUiState.from(cards)
         }
-    }
-
-    private fun List<PaymentCard>.toUiState(): PaymentCardsUiState = when {
-        this.isEmpty() -> PaymentCardsUiState.Empty
-        this.size == 1 -> PaymentCardsUiState.One(this.first())
-        else -> PaymentCardsUiState.Many(this)
     }
 }

--- a/app/src/main/java/nextstep/payments/ui/payments/PaymentCardsViewModel.kt
+++ b/app/src/main/java/nextstep/payments/ui/payments/PaymentCardsViewModel.kt
@@ -1,0 +1,36 @@
+package nextstep.payments.ui.payments
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import nextstep.payments.data.CachedPaymentRepository
+import nextstep.payments.domain.PaymentCard
+import nextstep.payments.domain.PaymentRepository
+
+class PaymentCardsViewModel(
+    private val paymentRepository: PaymentRepository = CachedPaymentRepository
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<PaymentCardsUiState>(PaymentCardsUiState.Empty)
+    val uiState: StateFlow<PaymentCardsUiState> = _uiState.asStateFlow()
+
+    init {
+        loadCardPayments()
+    }
+
+    fun loadCardPayments() {
+        viewModelScope.launch {
+            val paymentCards = paymentRepository.getPayments()
+            _uiState.value = paymentCards.toUiState()
+        }
+    }
+
+    private fun List<PaymentCard>.toUiState(): PaymentCardsUiState = when {
+        this.isEmpty() -> PaymentCardsUiState.Empty
+        this.size == 1 -> PaymentCardsUiState.One(this.first())
+        else -> PaymentCardsUiState.Many(this)
+    }
+}

--- a/app/src/main/java/nextstep/payments/ui/payments/PaymentCardsViewModel.kt
+++ b/app/src/main/java/nextstep/payments/ui/payments/PaymentCardsViewModel.kt
@@ -23,8 +23,7 @@ class PaymentCardsViewModel(
 
     fun loadCardPayments() {
         viewModelScope.launch {
-            val paymentCards = paymentRepository.getPayments()
-            _uiState.value = paymentCards.toUiState()
+            _uiState.value = paymentRepository.getPayments().toUiState()
         }
     }
 

--- a/app/src/main/java/nextstep/payments/ui/payments/component/PaymentCardList.kt
+++ b/app/src/main/java/nextstep/payments/ui/payments/component/PaymentCardList.kt
@@ -1,0 +1,88 @@
+package nextstep.payments.ui.payments.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import nextstep.payments.R
+import nextstep.payments.ui.component.AddCard
+import nextstep.payments.ui.component.PaymentCard
+import nextstep.payments.ui.payments.PaymentCardsUiState
+import nextstep.payments.ui.payments.PaymentCardsUiStatePreviewParameterProvider
+
+@Composable
+fun PaymentCardList(
+    uiState: PaymentCardsUiState,
+    onAddCardClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(top = 12.dp),
+        verticalArrangement = Arrangement.spacedBy(30.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        when (uiState) {
+            PaymentCardsUiState.Empty -> {
+                item {
+                    AddCardTitle(modifier = Modifier.padding(top = 20.dp))
+                }
+                item {
+                    AddCard(onClick = onAddCardClick)
+                }
+            }
+
+            is PaymentCardsUiState.One -> {
+                item {
+                    PaymentCard(payment = uiState.card)
+                }
+                item {
+                    AddCard(onClick = onAddCardClick)
+                }
+            }
+
+            is PaymentCardsUiState.Many -> {
+                items(uiState.cards) {
+                    PaymentCard(payment = it)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AddCardTitle(
+    modifier: Modifier = Modifier
+) {
+    Text(
+        modifier = modifier.fillMaxWidth(),
+        fontSize = 18.sp,
+        fontWeight = FontWeight.Bold,
+        text = stringResource(id = R.string.payments_add_card_title),
+        textAlign = TextAlign.Center
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PaymentCardListPreview(
+    @PreviewParameter(PaymentCardsUiStatePreviewParameterProvider::class) paymentCardsUiState: PaymentCardsUiState
+) {
+    PaymentCardList(
+        uiState = paymentCardsUiState,
+        onAddCardClick = {}
+    )
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,6 +2,10 @@
     <string name="app_name">Payments</string>
     <string name="app_on_back_click">뒤로 가기</string>
 
+    <string name="payments_title">Payments</string>
+    <string name="payments_add_card">추가</string>
+    <string name="payments_add_card_title">새로운 카드를 등록해주세요</string>
+
     <string name="add_card_title">카드 추가</string>
 
     <string name="card_number_label">카드 번호</string>


### PR DESCRIPTION
## 2단계 - 페이먼츠(카드 목록)

### 기능 요구 사항
- 카드 목록 화면을 구현하여 카드 추가 화면과 연결한다.
- 카드 목록 상태에 따른 UI 변경사항을 노출한다.
- 카드 목록이 비어있을 때에는 "새로운 카드를 등록해주세요" 안내가 노출되어야 한다.
- 카드 목록에 카드가 한 개 있을 때의 카드 추가 UI는 목록 하단에 노출된다.
- 카드 목록에 카드가 여러 개 있을 때의 카드 추가 UI는 상단바에 노출된다.

### 프로그래밍 요구 사항
- 카드 목록 데이터를 보관하기 위해 ViewModel과 StateFlow를 활용한다.
- 이외 목적으로 활용하는 것은 자유다.
- 카드 목록이 노출될 때 LazyColumn을 활용한다.
- 카드 목록 노출에 대한 검증을 UI 테스트로 만들어 본다.

---
이전 미션에서 배웠던 Navigation Compose를 활용해서 구현해봤어요 :)