### PR TITLE
🚀 4단계 - 페이먼츠(카드 수정)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,16 @@
 - (선택사항) 카드사를 선택할 때 적절한 카드사 아이콘을 노출한다.
 - 카드사 선택 기능 구현시 FlowRow와 ModalBottomSheet를 활용한다.
 
-### Step3 - 개선 사항
+#### Step3 - 개선 사항
 - BankLogo 컴포넌트 Image 컴포넌트로 대체
 - AppContainer, PaymentCard Size 상수로 추출 및 적용
 - NewCardScreen 등록 가능 유효성 체크 로직 ViewModel로 이동
 - BankSelectRow 1, 2번째 행 열 맞춤
 - bankType.bankImageRes!! > bankType.bankImageRes 되도록 로직 수정
 - BankBottomModalSheet 뒤로 가기 방지
+
+### Step4 - 페이먼츠(카드 수정)
+- 카드 수정 기능을 구현한다.
+  - 카드 목록에서 카드를 선택하면 카드 수정 화면으로 이동한다.
+  - 카드 수정 화면에서 변경사항이 발생하지 않으면 수정이 불가능하다.
+  - 카드가 수정되면 카드 목록 화면에 변경사항이 반영된다.

--- a/app/src/androidTest/java/nextstep/payments/CardListScreenTest.kt
+++ b/app/src/androidTest/java/nextstep/payments/CardListScreenTest.kt
@@ -43,6 +43,7 @@ class CardListScreenTest {
         composeTestRule.setContent {
             CardListScreen(
                 navigateToNewCard = {},
+                navigateToUpdateCard = {}
             )
         }
     }

--- a/app/src/androidTest/java/nextstep/payments/CardListScreenTest.kt
+++ b/app/src/androidTest/java/nextstep/payments/CardListScreenTest.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import nextstep.payments.data.model.Card
 import nextstep.payments.data.repository.PaymentCardsRepository
-import nextstep.payments.ui.BankType
+import nextstep.payments.ui.CardCompanyType
 import nextstep.payments.ui.screen.CardListScreen
 import org.junit.Rule
 import org.junit.Test
@@ -24,7 +24,7 @@ class CardListScreenTest {
         expiredDate = "1223",
         ownerName = "홍길동",
         password = "1234",
-        bankType = BankType.BC,
+        cardCompanyType = CardCompanyType.BC,
     )
 
     val card2 = Card(
@@ -32,7 +32,7 @@ class CardListScreenTest {
         expiredDate = "1223",
         ownerName = "홀리물리",
         password = "1234",
-        bankType = BankType.BC,
+        cardCompanyType = CardCompanyType.BC,
     )
 
     fun registerCards(vararg cards: Card) {

--- a/app/src/androidTest/java/nextstep/payments/CardListScreenTest.kt
+++ b/app/src/androidTest/java/nextstep/payments/CardListScreenTest.kt
@@ -1,5 +1,6 @@
 package nextstep.payments
 
+import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.filter
 import androidx.compose.ui.test.hasAnySibling
 import androidx.compose.ui.test.hasText
@@ -31,7 +32,7 @@ class CardListScreenTest {
         cardNumber = "1234567812345678",
         expiredDate = "1223",
         ownerName = "홀리물리",
-        password = "1234",
+        password = "1111",
         cardCompanyType = CardCompanyType.BC,
     )
 
@@ -73,11 +74,8 @@ class CardListScreenTest {
         )
 
         // 등록된 카드가 있을 때 카드가 화면에 노출되는지 확인
-        composeTestRule.onAllNodesWithText("홍길동")
-            .filter(hasAnySibling(hasText("1234")))
-            .filter(hasAnySibling(hasText("12 / 23")))
-            .onFirst()
-            .assertExists()
+        composeTestRule.onNodeWithText("홍길동")
+            .assert(hasText("1234") and hasText("12 / 23"))
     }
 
     @Test

--- a/app/src/androidTest/java/nextstep/payments/NewCardScreenRegisterTest.kt
+++ b/app/src/androidTest/java/nextstep/payments/NewCardScreenRegisterTest.kt
@@ -152,7 +152,7 @@ class NewCardScreenRegisterTest {
 
     @Test
     fun 화면_진입시_은행_선택_바텀_시트가_호출된다() {
-        composeTestRule.onNodeWithContentDescription("bankBottomSheet")
+        composeTestRule.onNodeWithContentDescription("cardCompanyBottomSheet")
             .assertIsDisplayed()
     }
 
@@ -163,7 +163,7 @@ class NewCardScreenRegisterTest {
             .performClick()
 
         // then
-        composeTestRule.onNodeWithContentDescription("bankBottomSheet")
+        composeTestRule.onNodeWithContentDescription("cardCompanyBottomSheet")
             .assertDoesNotExist()
     }
 

--- a/app/src/androidTest/java/nextstep/payments/NewCardScreenRegisterTest.kt
+++ b/app/src/androidTest/java/nextstep/payments/NewCardScreenRegisterTest.kt
@@ -13,7 +13,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
-class NewCardScreenTest {
+class NewCardScreenRegisterTest {
 
     @get:Rule
     val composeTestRule = createComposeRule()
@@ -23,7 +23,7 @@ class NewCardScreenTest {
         composeTestRule.setContent {
             NewCardScreen(
                 navigateToCardList = {},
-                card = null,
+                cardId = null,
             )
         }
     }

--- a/app/src/androidTest/java/nextstep/payments/NewCardScreenTest.kt
+++ b/app/src/androidTest/java/nextstep/payments/NewCardScreenTest.kt
@@ -22,7 +22,8 @@ class NewCardScreenTest {
     fun setUp() {
         composeTestRule.setContent {
             NewCardScreen(
-                navigateToCardList = {}
+                navigateToCardList = {},
+                card = null,
             )
         }
     }

--- a/app/src/androidTest/java/nextstep/payments/NewCardScreenUpdateTest.kt
+++ b/app/src/androidTest/java/nextstep/payments/NewCardScreenUpdateTest.kt
@@ -1,0 +1,80 @@
+package nextstep.payments
+
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import nextstep.payments.data.model.Card
+import nextstep.payments.data.repository.PaymentCardsRepository
+import nextstep.payments.ui.CardCompanyType
+import nextstep.payments.ui.screen.NewCardScreen
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class NewCardScreenUpdateTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Before
+    fun setUp() {
+        PaymentCardsRepository.clearCards()
+
+        PaymentCardsRepository.addCard(
+            Card(
+                cardId = "fdsafefefew-ewfwefwe-fewf",
+                cardNumber = "1234567812345678",
+                expiredDate = "1223",
+                ownerName = "홍길동",
+                password = "1234",
+                cardCompanyType = CardCompanyType.BC
+            )
+        )
+
+        composeTestRule.setContent {
+            NewCardScreen(
+                navigateToCardList = {},
+                cardId = "fdsafefefew-ewfwefwe-fewf",
+            )
+        }
+    }
+
+    @Test
+    fun 카드_아이디가_존재시_앱바_제목이_카드_수정으로_변경된다() {
+
+        composeTestRule.onNodeWithText("카드 수정")
+            .assertExists()
+    }
+
+    @Test
+    fun 카드_아이디가_존재시_카드_정보가_화면에_노출된다() {
+
+        composeTestRule.onNodeWithText("카드 번호")
+            .assert(hasText("1234 - 5678 - 1234 - 5678"))
+
+        composeTestRule.onNodeWithText("만료일")
+            .assert(hasText("12 / 23"))
+
+        composeTestRule.onNodeWithText("카드 소유자 이름(선택)")
+            .assert(hasText("홍길동"))
+
+        composeTestRule.onNodeWithText("비밀번호")
+            .assert(hasText("••••"))
+
+        composeTestRule.onNodeWithText("BC카드")
+            .assertExists()
+    }
+
+    @Test
+    fun 카드_수정시_변경사항이_없으면_수정_불가_스낵바를_호출한다() {
+        composeTestRule.onNodeWithContentDescription("addCardCheck")
+            .performClick()
+
+        // then
+        composeTestRule.onNodeWithContentDescription("validateSnackbar")
+            .assertIsDisplayed()
+    }
+}

--- a/app/src/main/java/nextstep/payments/data/model/Card.kt
+++ b/app/src/main/java/nextstep/payments/data/model/Card.kt
@@ -1,7 +1,9 @@
 package nextstep.payments.data.model
 
+import kotlinx.serialization.Serializable
 import nextstep.payments.ui.CardCompanyType
 
+@Serializable
 data class Card(
     val cardNumber: String,
     val expiredDate: String,

--- a/app/src/main/java/nextstep/payments/data/model/Card.kt
+++ b/app/src/main/java/nextstep/payments/data/model/Card.kt
@@ -2,9 +2,11 @@ package nextstep.payments.data.model
 
 import kotlinx.serialization.Serializable
 import nextstep.payments.ui.CardCompanyType
+import java.util.UUID
 
 @Serializable
 data class Card(
+    val cardId: String = UUID.randomUUID().toString(),
     val cardNumber: String,
     val expiredDate: String,
     val ownerName: String,

--- a/app/src/main/java/nextstep/payments/data/model/Card.kt
+++ b/app/src/main/java/nextstep/payments/data/model/Card.kt
@@ -1,11 +1,11 @@
 package nextstep.payments.data.model
 
-import nextstep.payments.ui.BankType
+import nextstep.payments.ui.CardCompanyType
 
 data class Card(
     val cardNumber: String,
     val expiredDate: String,
     val ownerName: String,
     val password: String,
-    val bankType: BankType,
+    val cardCompanyType: CardCompanyType,
 )

--- a/app/src/main/java/nextstep/payments/data/repository/PaymentCardsRepository.kt
+++ b/app/src/main/java/nextstep/payments/data/repository/PaymentCardsRepository.kt
@@ -11,6 +11,17 @@ object PaymentCardsRepository {
         _cards.add(card)
     }
 
+    fun updateCard(updatedCard: Card) {
+        val index = _cards.indexOfFirst { it.cardId == updatedCard.cardId }
+        if (index != -1) {
+            _cards[index] = updatedCard
+        }
+    }
+
+    fun getCardById(cardId: String): Card? {
+        return _cards.find { it.cardId == cardId }
+    }
+
     fun clearCards() {
         _cards.clear()
     }

--- a/app/src/main/java/nextstep/payments/ui/CardCompanyType.kt
+++ b/app/src/main/java/nextstep/payments/ui/CardCompanyType.kt
@@ -14,7 +14,7 @@ import nextstep.payments.ui.theme.LotteColor
 import nextstep.payments.ui.theme.ShinhanColor
 import nextstep.payments.ui.theme.WooriColor
 
-enum class BankType(
+enum class CardCompanyType(
     @StringRes val bankNameResId: Int,
     @DrawableRes val bankImageRes: Int?,
     val bankThemeColor: Color
@@ -30,6 +30,6 @@ enum class BankType(
     KB(R.string.bank_kb, R.drawable.kb, KBColor);
 
     companion object {
-        fun getBankList(): List<BankType> = entries.filter { it != NOT_SELECTED }
+        fun getBankList(): List<CardCompanyType> = entries.filter { it != NOT_SELECTED }
     }
 }

--- a/app/src/main/java/nextstep/payments/ui/CardCompanyType.kt
+++ b/app/src/main/java/nextstep/payments/ui/CardCompanyType.kt
@@ -14,18 +14,18 @@ import nextstep.payments.ui.theme.ShinhanColor
 import nextstep.payments.ui.theme.WooriColor
 
 enum class CardCompanyType(
-    @StringRes val bankNameResId: Int,
-    @DrawableRes val bankImageRes: Int?,
-    val bankThemeColor: Color
+    @StringRes val cardCompanyNameResId: Int,
+    @DrawableRes val cardCompanyImageRes: Int?,
+    val cardCompanyThemeColor: Color
 ) {
-    BC(R.string.bank_bc, R.drawable.bc, BcColor),
-    SHINHAN(R.string.bank_shinhan, R.drawable.shinhan, ShinhanColor),
-    KAKAO(R.string.bank_kakao, R.drawable.kakao, KakaoColor),
-    HYUNDAI(R.string.bank_hyundai, R.drawable.hyundai, HyundaiColor),
-    WOORI(R.string.bank_woori, R.drawable.woori, WooriColor),
-    LOTTE(R.string.bank_lotte, R.drawable.lotte, LotteColor),
-    HANA(R.string.bank_hana, R.drawable.hana, HanaColor),
-    KB(R.string.bank_kb, R.drawable.kb, KBColor);
+    BC(R.string.card_company_bc, R.drawable.bc, BcColor),
+    SHINHAN(R.string.card_company_shinhan, R.drawable.shinhan, ShinhanColor),
+    KAKAO(R.string.card_company_kakao, R.drawable.kakao, KakaoColor),
+    HYUNDAI(R.string.card_company_hyundai, R.drawable.hyundai, HyundaiColor),
+    WOORI(R.string.card_company_woori, R.drawable.woori, WooriColor),
+    LOTTE(R.string.card_company_lotte, R.drawable.lotte, LotteColor),
+    HANA(R.string.card_company_hana, R.drawable.hana, HanaColor),
+    KB(R.string.card_company_kb, R.drawable.kb, KBColor);
 
     companion object {
         fun getBankList(): List<CardCompanyType> = entries

--- a/app/src/main/java/nextstep/payments/ui/CardCompanyType.kt
+++ b/app/src/main/java/nextstep/payments/ui/CardCompanyType.kt
@@ -5,7 +5,6 @@ import androidx.annotation.StringRes
 import androidx.compose.ui.graphics.Color
 import nextstep.payments.R
 import nextstep.payments.ui.theme.BcColor
-import nextstep.payments.ui.theme.DefaultBankColor
 import nextstep.payments.ui.theme.HanaColor
 import nextstep.payments.ui.theme.HyundaiColor
 import nextstep.payments.ui.theme.KBColor
@@ -19,7 +18,6 @@ enum class CardCompanyType(
     @DrawableRes val bankImageRes: Int?,
     val bankThemeColor: Color
 ) {
-    NOT_SELECTED(R.string.bank_not_select, null, DefaultBankColor),
     BC(R.string.bank_bc, R.drawable.bc, BcColor),
     SHINHAN(R.string.bank_shinhan, R.drawable.shinhan, ShinhanColor),
     KAKAO(R.string.bank_kakao, R.drawable.kakao, KakaoColor),
@@ -30,6 +28,6 @@ enum class CardCompanyType(
     KB(R.string.bank_kb, R.drawable.kb, KBColor);
 
     companion object {
-        fun getBankList(): List<CardCompanyType> = entries.filter { it != NOT_SELECTED }
+        fun getBankList(): List<CardCompanyType> = entries
     }
 }

--- a/app/src/main/java/nextstep/payments/ui/screen/CardApp.kt
+++ b/app/src/main/java/nextstep/payments/ui/screen/CardApp.kt
@@ -11,8 +11,6 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
-import kotlinx.serialization.json.Json
-import nextstep.payments.data.model.Card
 import nextstep.payments.ui.screen.navigation.CardRoute
 
 
@@ -38,7 +36,7 @@ fun CardApp(
                     navigateToNewCard = {
                         navController.navigate(CardRoute.NewCard.route)
                     },
-                    navigateToModifyCard = { cardId ->
+                    navigateToUpdateCard = { cardId ->
                         navController.navigate(CardRoute.NewCard.withId(cardId))
                     }
                 )

--- a/app/src/main/java/nextstep/payments/ui/screen/CardApp.kt
+++ b/app/src/main/java/nextstep/payments/ui/screen/CardApp.kt
@@ -10,6 +10,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
+import kotlinx.serialization.json.Json
+import nextstep.payments.data.model.Card
 import nextstep.payments.ui.screen.navigation.CardRoute
 
 
@@ -25,25 +28,37 @@ fun CardApp(
     ) {
         NavHost(
             navController = navController,
-            startDestination = CardRoute.CardList,
+            startDestination = CardRoute.CardList.route,
             modifier = modifier
                 .fillMaxSize()
                 .padding(it)
         ) {
-            composable<CardRoute.CardList> {
+            composable(CardRoute.CardList.route) {
                 CardListScreen(
                     navigateToNewCard = {
-                        navController.navigate(CardRoute.NewCard)
+                        navController.navigate(CardRoute.NewCard.route)
+                    },
+                    navigateToModifyCard = {
+                        navController.navigate(CardRoute.NewCard.withArgs(it))
                     }
                 )
             }
-            composable<CardRoute.NewCard> {
+
+            composable(
+                route = "${CardRoute.NewCard.route}?card={card}",
+                arguments = listOf(navArgument("card") { nullable = true })
+            ) { backStackEntry ->
+                val cardJson = backStackEntry.arguments?.getString("card")
+                val card = cardJson?.let {
+                    runCatching { Json.decodeFromString<Card>(it) }.getOrNull()
+                }
+
                 NewCardScreen(
-                    navigateToCardList = {
-                        navController.navigateUp()
-                    }
+                    navigateToCardList = { navController.navigateUp() },
+                    card = card
                 )
             }
+
         }
     }
 }

--- a/app/src/main/java/nextstep/payments/ui/screen/CardApp.kt
+++ b/app/src/main/java/nextstep/payments/ui/screen/CardApp.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
-import androidx.navigation.navArgument
+import androidx.navigation.toRoute
 import nextstep.payments.ui.screen.navigation.CardRoute
 
 
@@ -26,27 +26,25 @@ fun CardApp(
     ) {
         NavHost(
             navController = navController,
-            startDestination = CardRoute.CardList.route,
+            startDestination = CardRoute.CardList,
             modifier = modifier
                 .fillMaxSize()
                 .padding(it)
         ) {
-            composable(CardRoute.CardList.route) {
+            composable<CardRoute.CardList> {
                 CardListScreen(
                     navigateToNewCard = {
-                        navController.navigate(CardRoute.NewCard.route)
+                        navController.navigate(CardRoute.NewCard(null))
                     },
                     navigateToUpdateCard = { cardId ->
-                        navController.navigate(CardRoute.NewCard.withId(cardId))
+                        navController.navigate(CardRoute.NewCard(cardId))
                     }
                 )
             }
 
-            composable(
-                route = "${CardRoute.NewCard.route}?cardId={cardId}",
-                arguments = listOf(navArgument("cardId") { nullable = true })
-            ) { backStackEntry ->
-                val cardId = backStackEntry.arguments?.getString("cardId")
+            composable<CardRoute.NewCard> { backStackEntry ->
+                val newCard: CardRoute.NewCard = backStackEntry.toRoute()
+                val cardId = newCard.cardId
 
                 NewCardScreen(
                     cardId = cardId,

--- a/app/src/main/java/nextstep/payments/ui/screen/CardApp.kt
+++ b/app/src/main/java/nextstep/payments/ui/screen/CardApp.kt
@@ -38,27 +38,23 @@ fun CardApp(
                     navigateToNewCard = {
                         navController.navigate(CardRoute.NewCard.route)
                     },
-                    navigateToModifyCard = {
-                        navController.navigate(CardRoute.NewCard.withArgs(it))
+                    navigateToModifyCard = { cardId ->
+                        navController.navigate(CardRoute.NewCard.withId(cardId))
                     }
                 )
             }
 
             composable(
-                route = "${CardRoute.NewCard.route}?card={card}",
-                arguments = listOf(navArgument("card") { nullable = true })
+                route = "${CardRoute.NewCard.route}?cardId={cardId}",
+                arguments = listOf(navArgument("cardId") { nullable = true })
             ) { backStackEntry ->
-                val cardJson = backStackEntry.arguments?.getString("card")
-                val card = cardJson?.let {
-                    runCatching { Json.decodeFromString<Card>(it) }.getOrNull()
-                }
+                val cardId = backStackEntry.arguments?.getString("cardId")
 
                 NewCardScreen(
-                    navigateToCardList = { navController.navigateUp() },
-                    card = card
+                    cardId = cardId,
+                    navigateToCardList = { navController.navigateUp() }
                 )
             }
-
         }
     }
 }

--- a/app/src/main/java/nextstep/payments/ui/screen/CartListScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/screen/CartListScreen.kt
@@ -49,7 +49,7 @@ import nextstep.payments.ui.viewmodel.CardListViewModel
 @Composable
 fun CardListScreen(
     navigateToNewCard: () -> Unit,
-    navigateToModifyCard: (card: Card) -> Unit,
+    navigateToModifyCard: (String) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: CardListViewModel = viewModel(),
 ) {
@@ -104,7 +104,7 @@ fun CardListScreen(
                     OneCardContainer(
                         card = cardsState.data,
                         onCardClick = {
-                            navigateToModifyCard(cardsState.data)
+                            navigateToModifyCard(cardsState.data.cardId)
                         },
                         onClick = {
                             navigateToNewCard()

--- a/app/src/main/java/nextstep/payments/ui/screen/CartListScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/screen/CartListScreen.kt
@@ -42,6 +42,7 @@ import nextstep.payments.ui.CardUiState
 import nextstep.payments.ui.screen.component.CenterTopBar
 import nextstep.payments.ui.screen.component.PaymentCard
 import nextstep.payments.ui.theme.Dimensions
+import nextstep.payments.ui.theme.Dimensions.CardRatioDefaults
 import nextstep.payments.ui.viewmodel.CardListViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -169,7 +170,7 @@ private fun AddCardContainer(
     Box(
         modifier = modifier
             .width(Dimensions.CardWidthDefaults)
-            .aspectRatio(52 / 31f)
+            .aspectRatio(CardRatioDefaults)
             .background(
                 color = Color(0xFFE5E5E5),
                 shape = RoundedCornerShape(5.dp),

--- a/app/src/main/java/nextstep/payments/ui/screen/CartListScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/screen/CartListScreen.kt
@@ -49,6 +49,7 @@ import nextstep.payments.ui.viewmodel.CardListViewModel
 @Composable
 fun CardListScreen(
     navigateToNewCard: () -> Unit,
+    navigateToModifyCard: (card: Card) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: CardListViewModel = viewModel(),
 ) {
@@ -102,6 +103,9 @@ fun CardListScreen(
                 is CardUiState.One -> {
                     OneCardContainer(
                         card = cardsState.data,
+                        onCardClick = {
+                            navigateToModifyCard(cardsState.data)
+                        },
                         onClick = {
                             navigateToNewCard()
                         }
@@ -122,6 +126,7 @@ fun CardListScreen(
 private fun OneCardContainer(
     card: Card,
     onClick: () -> Unit,
+    onCardClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -133,6 +138,9 @@ private fun OneCardContainer(
             expiredDate = card.expiredDate,
             ownerName = card.ownerName,
             cardColor = card.cardCompanyType.bankThemeColor,
+            modifier = Modifier.clickable(
+                onClick = onCardClick
+            )
         )
         Spacer(modifier = Modifier.height(36.dp))
         AddCardContainer(
@@ -203,6 +211,7 @@ private fun OneCardContainerPreview() {
             password = "12421412",
             cardCompanyType = CardCompanyType.BC,
         ),
+        onCardClick = {},
         onClick = {},
     )
 }
@@ -241,6 +250,7 @@ private fun CardListConatinerPreview() {
 @Composable
 private fun CardListScreenPreview() {
     CardListScreen(
-        navigateToNewCard = {}
+        navigateToModifyCard = {},
+        navigateToNewCard = {},
     )
 }

--- a/app/src/main/java/nextstep/payments/ui/screen/CartListScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/screen/CartListScreen.kt
@@ -37,7 +37,7 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import nextstep.payments.R
 import nextstep.payments.data.model.Card
-import nextstep.payments.ui.BankType
+import nextstep.payments.ui.CardCompanyType
 import nextstep.payments.ui.CardUiState
 import nextstep.payments.ui.screen.component.CenterTopBar
 import nextstep.payments.ui.screen.component.PaymentCard
@@ -128,11 +128,11 @@ private fun OneCardContainer(
         modifier = modifier,
     ) {
         PaymentCard(
-            bankName = stringResource(card.bankType.bankNameResId),
+            bankName = stringResource(card.cardCompanyType.bankNameResId),
             cardNumber = card.cardNumber,
             expiredDate = card.expiredDate,
             ownerName = card.ownerName,
-            cardColor = card.bankType.bankThemeColor,
+            cardColor = card.cardCompanyType.bankThemeColor,
         )
         Spacer(modifier = Modifier.height(36.dp))
         AddCardContainer(
@@ -152,11 +152,11 @@ private fun CardListContainer(
     ) {
         items(cardList) { card ->
             PaymentCard(
-                bankName = card.bankType.name,
+                bankName = card.cardCompanyType.name,
                 cardNumber = card.cardNumber,
                 expiredDate = card.expiredDate,
                 ownerName = card.ownerName,
-                cardColor = card.bankType.bankThemeColor,
+                cardColor = card.cardCompanyType.bankThemeColor,
             )
         }
     }
@@ -201,7 +201,7 @@ private fun OneCardContainerPreview() {
             expiredDate = "1234",
             ownerName = "홍길동",
             password = "12421412",
-            bankType = BankType.BC,
+            cardCompanyType = CardCompanyType.BC,
         ),
         onClick = {},
     )
@@ -217,21 +217,21 @@ private fun CardListConatinerPreview() {
                 expiredDate = "1234",
                 ownerName = "홍길동",
                 password = "12421412",
-                bankType = BankType.BC
+                cardCompanyType = CardCompanyType.BC
             ),
             Card(
                 cardNumber = "1234-5678-1234-5678",
                 expiredDate = "1234",
                 ownerName = "홍길동",
                 password = "12421412",
-                bankType = BankType.BC
+                cardCompanyType = CardCompanyType.BC
             ),
             Card(
                 cardNumber = "1234-5678-1234-5678",
                 expiredDate = "1234",
                 ownerName = "홍길동",
                 password = "12421412",
-                bankType = BankType.BC
+                cardCompanyType = CardCompanyType.BC
             ),
         )
     )

--- a/app/src/main/java/nextstep/payments/ui/screen/CartListScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/screen/CartListScreen.kt
@@ -49,7 +49,7 @@ import nextstep.payments.ui.viewmodel.CardListViewModel
 @Composable
 fun CardListScreen(
     navigateToNewCard: () -> Unit,
-    navigateToModifyCard: (String) -> Unit,
+    navigateToUpdateCard: (String) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: CardListViewModel = viewModel(),
 ) {
@@ -104,7 +104,7 @@ fun CardListScreen(
                     OneCardContainer(
                         card = cardsState.data,
                         onCardClick = {
-                            navigateToModifyCard(cardsState.data.cardId)
+                            navigateToUpdateCard(cardsState.data.cardId)
                         },
                         onClick = {
                             navigateToNewCard()
@@ -114,7 +114,10 @@ fun CardListScreen(
 
                 is CardUiState.Many -> {
                     CardListContainer(
-                        cardList = cardsState.data
+                        cardList = cardsState.data,
+                        onCardClick = { cardId ->
+                            navigateToUpdateCard(cardId)
+                        }
                     )
                 }
             }
@@ -152,9 +155,11 @@ private fun OneCardContainer(
 @Composable
 private fun CardListContainer(
     cardList: List<Card>,
+    onCardClick: (String) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     LazyColumn(
-        modifier = Modifier.padding(horizontal = 16.dp),
+        modifier = modifier.padding(horizontal = 16.dp),
         verticalArrangement = Arrangement.spacedBy(36.dp),
         contentPadding = PaddingValues(12.dp),
     ) {
@@ -165,6 +170,9 @@ private fun CardListContainer(
                 expiredDate = card.expiredDate,
                 ownerName = card.ownerName,
                 cardColor = card.cardCompanyType.bankThemeColor,
+                modifier = Modifier.clickable(
+                    onClick = { onCardClick(card.cardId) }
+                )
             )
         }
     }
@@ -242,7 +250,8 @@ private fun CardListConatinerPreview() {
                 password = "12421412",
                 cardCompanyType = CardCompanyType.BC
             ),
-        )
+        ),
+        onCardClick = {},
     )
 }
 
@@ -250,7 +259,7 @@ private fun CardListConatinerPreview() {
 @Composable
 private fun CardListScreenPreview() {
     CardListScreen(
-        navigateToModifyCard = {},
+        navigateToUpdateCard = {},
         navigateToNewCard = {},
     )
 }

--- a/app/src/main/java/nextstep/payments/ui/screen/CartListScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/screen/CartListScreen.kt
@@ -136,11 +136,11 @@ private fun OneCardContainer(
         modifier = modifier,
     ) {
         PaymentCard(
-            bankName = stringResource(card.cardCompanyType.bankNameResId),
+            cardCompanyName = stringResource(card.cardCompanyType.cardCompanyNameResId),
             cardNumber = card.cardNumber,
             expiredDate = card.expiredDate,
             ownerName = card.ownerName,
-            cardColor = card.cardCompanyType.bankThemeColor,
+            cardColor = card.cardCompanyType.cardCompanyThemeColor,
             modifier = Modifier.clickable(
                 onClick = onCardClick
             )
@@ -165,11 +165,11 @@ private fun CardListContainer(
     ) {
         items(cardList) { card ->
             PaymentCard(
-                bankName = card.cardCompanyType.name,
+                cardCompanyName = card.cardCompanyType.name,
                 cardNumber = card.cardNumber,
                 expiredDate = card.expiredDate,
                 ownerName = card.ownerName,
-                cardColor = card.cardCompanyType.bankThemeColor,
+                cardColor = card.cardCompanyType.cardCompanyThemeColor,
                 modifier = Modifier.clickable(
                     onClick = { onCardClick(card.cardId) }
                 )

--- a/app/src/main/java/nextstep/payments/ui/screen/NewCardScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/screen/NewCardScreen.kt
@@ -61,7 +61,7 @@ import nextstep.payments.ui.viewmodel.NewCardViewModel
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun NewCardScreen(
-    card: Card?,
+    cardId: String?,
     navigateToCardList: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: NewCardViewModel = viewModel(),
@@ -452,7 +452,7 @@ private fun PasswordInputFieldPreview() {
 @Composable
 private fun StatefulNewCardScreenPreview() {
     NewCardScreen(
-        card = null,
+        cardId = null,
         viewModel = NewCardViewModel().apply {
             setCardNumber("1234567812345678")
             setExpiredDate("12 / 34")

--- a/app/src/main/java/nextstep/payments/ui/screen/NewCardScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/screen/NewCardScreen.kt
@@ -112,24 +112,10 @@ fun NewCardScreen(
     }
 
     LaunchedEffect(Unit) {
-        viewModel.updateCardState.collectLatest { isUpdatable ->
-            if (!isUpdatable) {
-                coroutineScope.launch {
-                    snackbarHostState.showSnackbar(snackbarMessage)
-                }
-
-                return@collectLatest
-            }
-
-            navigateToCardList()
-        }
-    }
-
-    LaunchedEffect(Unit) {
         viewModel.saveState.collectLatest { state ->
             when (state) {
                 is SaveState.UpdateCard -> {
-
+                    navigateToCardList()
                 }
 
                 is SaveState.SaveNewCard -> {

--- a/app/src/main/java/nextstep/payments/ui/screen/NewCardScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/screen/NewCardScreen.kt
@@ -85,6 +85,13 @@ fun NewCardScreen(
 
     val coroutineScope = rememberCoroutineScope()
 
+    LaunchedEffect(Unit) {
+        if (cardId != null) {
+            viewModel.getCardById(cardId)
+            isBottomSheetVisible = false
+        }
+    }
+
     LaunchedEffect(isBottomSheetVisible) {
         if (isBottomSheetVisible) {
             sheetState.show()
@@ -92,6 +99,7 @@ fun NewCardScreen(
     }
 
     NewCardScreen(
+        cardId = cardId,
         cardNumber = cardNumber,
         expiredDate = expiredDate,
         ownerName = ownerName,
@@ -106,6 +114,22 @@ fun NewCardScreen(
         onBackCLick = navigateToCardList,
         onSaveClick = {
             viewModel.addCard(
+                cardNumber = cardNumber,
+                expiredDate = expiredDate,
+                ownerName = ownerName,
+                password = password,
+                cardCompanyType = selectedCardCompany
+            )
+
+            navigateToCardList()
+        },
+        onUpdateClick = {
+            if (cardId == null) {
+                return@NewCardScreen
+            }
+
+            viewModel.updateCard(
+                cardId = cardId,
                 cardNumber = cardNumber,
                 expiredDate = expiredDate,
                 ownerName = ownerName,
@@ -135,6 +159,7 @@ fun NewCardScreen(
 
 @Composable
 private fun NewCardScreen(
+    cardId: String?,
     cardNumber: String,
     expiredDate: String,
     ownerName: String,
@@ -148,24 +173,39 @@ private fun NewCardScreen(
     setPassword: (String) -> Unit,
     onBackCLick: () -> Unit,
     onSaveClick: () -> Unit,
+    onUpdateClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
     val snackbarMessage = remember { context.getString(R.string.validate_snack_bar_message) }
     val coroutineScope = rememberCoroutineScope()
 
+    val appBarTitle = if (cardId == null) {
+        stringResource(R.string.card_add_app_bar_title)
+    } else {
+        stringResource(R.string.card_update_app_bar_title)
+    }
+
     Scaffold(
         topBar = {
-            NewCardTopBar(onBackClick = onBackCLick, onSaveClick = {
-                if (isSaveEnabled) {
-                    onSaveClick()
-                    return@NewCardTopBar
-                }
+            NewCardTopBar(
+                appbarTitle = appBarTitle,
+                onBackClick = onBackCLick,
+                onSaveClick = {
+                    if (cardId != null && isSaveEnabled) {
+                        onUpdateClick()
+                        return@NewCardTopBar
+                    }
 
-                coroutineScope.launch {
-                    snackbarHostState.showSnackbar(snackbarMessage)
-                }
-            })
+                    if (isSaveEnabled) {
+                        onSaveClick()
+                        return@NewCardTopBar
+                    }
+
+                    coroutineScope.launch {
+                        snackbarHostState.showSnackbar(snackbarMessage)
+                    }
+                })
         },
         snackbarHost = {
             SnackbarHost(
@@ -467,6 +507,7 @@ private fun StatefulNewCardScreenPreview() {
 @Composable
 private fun StatelessNewCardScreenPreView() {
     NewCardScreen(
+        cardId = null,
         cardNumber = "1234567812345678",
         expiredDate = "12 / 34",
         ownerName = "홍길동",
@@ -480,5 +521,6 @@ private fun StatelessNewCardScreenPreView() {
         setPassword = {},
         onBackCLick = {},
         onSaveClick = {},
+        onUpdateClick = {},
     )
 }

--- a/app/src/main/java/nextstep/payments/ui/screen/NewCardScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/screen/NewCardScreen.kt
@@ -88,7 +88,7 @@ fun NewCardScreen(
 
     LaunchedEffect(Unit) {
         if (cardId != null) {
-            viewModel.getCardById(cardId)
+            viewModel.fetchCardById(cardId)
             isBottomSheetVisible = false
         }
     }

--- a/app/src/main/java/nextstep/payments/ui/screen/NewCardScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/screen/NewCardScreen.kt
@@ -99,6 +99,20 @@ fun NewCardScreen(
         }
     }
 
+    LaunchedEffect(Unit) {
+        viewModel.updateCardState.collect { isUpdatable ->
+            if (!isUpdatable) {
+                coroutineScope.launch {
+                    snackbarHostState.showSnackbar(snackbarMessage)
+                }
+
+                return@collect
+            }
+
+            navigateToCardList()
+        }
+    }
+
     NewCardScreen(
         cardId = cardId,
         cardNumber = cardNumber,
@@ -129,7 +143,7 @@ fun NewCardScreen(
                 return@NewCardScreen
             }
 
-            val updateSuccess = viewModel.updateCard(
+            viewModel.updateCard(
                 cardId = cardId,
                 cardNumber = cardNumber,
                 expiredDate = expiredDate,
@@ -137,16 +151,6 @@ fun NewCardScreen(
                 password = password,
                 cardCompanyType = selectedCardCompany
             )
-
-            if(!updateSuccess) {
-                coroutineScope.launch {
-                    snackbarHostState.showSnackbar(snackbarMessage)
-                }
-
-                return@NewCardScreen
-            }
-
-            navigateToCardList()
         },
         modifier = modifier
     )

--- a/app/src/main/java/nextstep/payments/ui/screen/NewCardScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/screen/NewCardScreen.kt
@@ -48,6 +48,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import kotlinx.coroutines.launch
 import nextstep.payments.R
+import nextstep.payments.data.model.Card
 import nextstep.payments.ui.CardCompanyType
 import nextstep.payments.ui.screen.component.NewCardTopBar
 import nextstep.payments.ui.screen.component.OutlinedInputTextField
@@ -60,6 +61,7 @@ import nextstep.payments.ui.viewmodel.NewCardViewModel
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun NewCardScreen(
+    card: Card?,
     navigateToCardList: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: NewCardViewModel = viewModel(),
@@ -450,6 +452,7 @@ private fun PasswordInputFieldPreview() {
 @Composable
 private fun StatefulNewCardScreenPreview() {
     NewCardScreen(
+        card = null,
         viewModel = NewCardViewModel().apply {
             setCardNumber("1234567812345678")
             setExpiredDate("12 / 34")

--- a/app/src/main/java/nextstep/payments/ui/screen/NewCardScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/screen/NewCardScreen.kt
@@ -48,7 +48,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import kotlinx.coroutines.launch
 import nextstep.payments.R
-import nextstep.payments.data.model.Card
 import nextstep.payments.ui.CardCompanyType
 import nextstep.payments.ui.screen.component.NewCardTopBar
 import nextstep.payments.ui.screen.component.OutlinedInputTextField
@@ -66,6 +65,8 @@ fun NewCardScreen(
     modifier: Modifier = Modifier,
     viewModel: NewCardViewModel = viewModel(),
 ) {
+    val context = LocalContext.current
+
     val cardNumber by viewModel.cardNumber.collectAsStateWithLifecycle()
     val expiredDate by viewModel.expiredDate.collectAsStateWithLifecycle()
     val ownerName by viewModel.ownerName.collectAsStateWithLifecycle()
@@ -82,7 +83,7 @@ fun NewCardScreen(
 
     // 스낵바 상태 저장
     val snackbarHostState = remember { SnackbarHostState() }
-
+    val snackbarMessage = remember { context.getString(R.string.validate_modify_snack_bar_message) }
     val coroutineScope = rememberCoroutineScope()
 
     LaunchedEffect(Unit) {
@@ -128,7 +129,7 @@ fun NewCardScreen(
                 return@NewCardScreen
             }
 
-            viewModel.updateCard(
+            val updateSuccess = viewModel.updateCard(
                 cardId = cardId,
                 cardNumber = cardNumber,
                 expiredDate = expiredDate,
@@ -136,6 +137,14 @@ fun NewCardScreen(
                 password = password,
                 cardCompanyType = selectedCardCompany
             )
+
+            if(!updateSuccess) {
+                coroutineScope.launch {
+                    snackbarHostState.showSnackbar(snackbarMessage)
+                }
+
+                return@NewCardScreen
+            }
 
             navigateToCardList()
         },
@@ -178,6 +187,7 @@ private fun NewCardScreen(
 ) {
     val context = LocalContext.current
     val snackbarMessage = remember { context.getString(R.string.validate_snack_bar_message) }
+
     val coroutineScope = rememberCoroutineScope()
 
     val appBarTitle = if (cardId == null) {

--- a/app/src/main/java/nextstep/payments/ui/screen/NewCardScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/screen/NewCardScreen.kt
@@ -70,8 +70,8 @@ fun NewCardScreen(
     val password by viewModel.password.collectAsStateWithLifecycle()
     val isSaveEnabled by viewModel.isSaveEnabled.collectAsStateWithLifecycle()
 
-    val selectedBank by viewModel.selectedBank.collectAsStateWithLifecycle()
-    var isBottomSheetVisible by remember { mutableStateOf(false) }
+    val selectedCardCompany by viewModel.selectedCardCompany.collectAsStateWithLifecycle()
+    var isBottomSheetVisible by remember { mutableStateOf(true) }
     var sheetState = rememberModalBottomSheetState(
         confirmValueChange = { newState ->
             newState != SheetValue.Hidden
@@ -81,15 +81,11 @@ fun NewCardScreen(
     // 스낵바 상태 저장
     val snackbarHostState = remember { SnackbarHostState() }
 
-    LaunchedEffect(selectedBank) {
-        if (selectedBank == CardCompanyType.NOT_SELECTED) {
-            isBottomSheetVisible = true
-            sheetState.show()
-        }
+    val coroutineScope = rememberCoroutineScope()
 
-        if (selectedBank != CardCompanyType.NOT_SELECTED) {
-            isBottomSheetVisible = false
-            sheetState.hide()
+    LaunchedEffect(isBottomSheetVisible) {
+        if (isBottomSheetVisible) {
+            sheetState.show()
         }
     }
 
@@ -98,7 +94,7 @@ fun NewCardScreen(
         expiredDate = expiredDate,
         ownerName = ownerName,
         password = password,
-        selectedBank = selectedBank,
+        selectedBank = selectedCardCompany,
         isSaveEnabled = isSaveEnabled,
         setCardNumber = viewModel::setCardNumber,
         setExpiredDate = viewModel::setExpiredDate,
@@ -112,8 +108,9 @@ fun NewCardScreen(
                 expiredDate = expiredDate,
                 ownerName = ownerName,
                 password = password,
-                cardCompanyType = selectedBank
+                cardCompanyType = selectedCardCompany
             )
+
             navigateToCardList()
         },
         modifier = modifier
@@ -122,7 +119,13 @@ fun NewCardScreen(
     if (isBottomSheetVisible) {
         BankBottomModalSheet(
             sheetState = sheetState,
-            onBankClick = viewModel::setSelectedBank,
+            onBankClick = { selectedCardCompanyType ->
+                viewModel.setSelectedBank(selectedCardCompanyType)
+                coroutineScope.launch {
+                    sheetState.hide()
+                    isBottomSheetVisible = false
+                }
+            },
             modifier = Modifier.fillMaxWidth(),
         )
     }
@@ -134,7 +137,7 @@ private fun NewCardScreen(
     expiredDate: String,
     ownerName: String,
     password: String,
-    selectedBank: CardCompanyType,
+    selectedBank: CardCompanyType?,
     isSaveEnabled: Boolean,
     snackbarHostState: SnackbarHostState,
     setCardNumber: (String) -> Unit,
@@ -179,13 +182,22 @@ private fun NewCardScreen(
         ) {
             Spacer(modifier = Modifier.height(14.dp))
 
-            PaymentCard(
-                bankName = stringResource(selectedBank.bankNameResId),
-                cardNumber = cardNumber,
-                expiredDate = expiredDate,
-                ownerName = ownerName,
-                cardColor = selectedBank.bankThemeColor,
-            )
+            if (selectedBank != null) {
+                PaymentCard(
+                    bankName = stringResource(selectedBank.bankNameResId),
+                    cardNumber = cardNumber,
+                    expiredDate = expiredDate,
+                    ownerName = ownerName,
+                    cardColor = selectedBank.bankThemeColor,
+                )
+            } else {
+                PaymentCard(
+                    bankName = "00",
+                    cardNumber = cardNumber,
+                    expiredDate = expiredDate,
+                    ownerName = ownerName,
+                )
+            }
 
             Spacer(modifier = Modifier.height(10.dp))
 
@@ -344,7 +356,8 @@ private fun BankSelectRow(
             BankItem(
                 bankName = stringResource(bankType.bankNameResId),
                 bankImage = painterResource(bankType.bankImageRes),
-                modifier = modifier.width(80.dp)
+                modifier = modifier
+                    .width(80.dp)
                     .clickable(
                         onClick = { onBankClick(bankType) },
                         indication = null,

--- a/app/src/main/java/nextstep/payments/ui/screen/NewCardScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/screen/NewCardScreen.kt
@@ -105,7 +105,7 @@ fun NewCardScreen(
         expiredDate = expiredDate,
         ownerName = ownerName,
         password = password,
-        selectedBank = selectedCardCompany,
+        selectedCardCompany = selectedCardCompany,
         isSaveEnabled = isSaveEnabled,
         setCardNumber = viewModel::setCardNumber,
         setExpiredDate = viewModel::setExpiredDate,
@@ -173,7 +173,7 @@ private fun NewCardScreen(
     expiredDate: String,
     ownerName: String,
     password: String,
-    selectedBank: CardCompanyType?,
+    selectedCardCompany: CardCompanyType?,
     isSaveEnabled: Boolean,
     snackbarHostState: SnackbarHostState,
     setCardNumber: (String) -> Unit,
@@ -234,13 +234,13 @@ private fun NewCardScreen(
         ) {
             Spacer(modifier = Modifier.height(14.dp))
 
-            if (selectedBank != null) {
+            if (selectedCardCompany != null) {
                 PaymentCard(
-                    bankName = stringResource(selectedBank.bankNameResId),
+                    bankName = stringResource(selectedCardCompany.bankNameResId),
                     cardNumber = cardNumber,
                     expiredDate = expiredDate,
                     ownerName = ownerName,
-                    cardColor = selectedBank.bankThemeColor,
+                    cardColor = selectedCardCompany.bankThemeColor,
                 )
             } else {
                 PaymentCard(
@@ -523,7 +523,7 @@ private fun StatelessNewCardScreenPreView() {
         ownerName = "홍길동",
         password = "1234",
         isSaveEnabled = true,
-        selectedBank = CardCompanyType.BC,
+        selectedCardCompany = CardCompanyType.BC,
         snackbarHostState = SnackbarHostState(),
         setCardNumber = {},
         setExpiredDate = {},

--- a/app/src/main/java/nextstep/payments/ui/screen/NewCardScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/screen/NewCardScreen.kt
@@ -81,9 +81,6 @@ fun NewCardScreen(
     // 스낵바 상태 저장
     val snackbarHostState = remember { SnackbarHostState() }
 
-    // 저장 가능 여부 유효성 체크
-    viewModel.setIsSaveEnabled()
-
     LaunchedEffect(selectedBank) {
         if (selectedBank == BankType.NOT_SELECTED) {
             isBottomSheetVisible = true

--- a/app/src/main/java/nextstep/payments/ui/screen/NewCardScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/screen/NewCardScreen.kt
@@ -239,15 +239,15 @@ private fun NewCardScreen(
 
             if (selectedCardCompany != null) {
                 PaymentCard(
-                    bankName = stringResource(selectedCardCompany.bankNameResId),
+                    cardCompanyName = stringResource(selectedCardCompany.cardCompanyNameResId),
                     cardNumber = cardNumber,
                     expiredDate = expiredDate,
                     ownerName = ownerName,
-                    cardColor = selectedCardCompany.bankThemeColor,
+                    cardColor = selectedCardCompany.cardCompanyThemeColor,
                 )
             } else {
                 PaymentCard(
-                    bankName = "00",
+                    cardCompanyName = "00",
                     cardNumber = cardNumber,
                     expiredDate = expiredDate,
                     ownerName = ownerName,
@@ -365,7 +365,7 @@ private fun BankBottomModalSheet(
 ) {
     ModalBottomSheet(
         modifier = modifier.semantics {
-            contentDescription = "bankBottomSheet"
+            contentDescription = "cardCompanyBottomSheet"
         },
         sheetState = sheetState,
         onDismissRequest = {},
@@ -378,8 +378,8 @@ private fun BankBottomModalSheet(
 
             // 은행 리스트
             BankSelectRow(
-                onBankClick = { bankType ->
-                    onBankClick(bankType)
+                onBankClick = { cardCompanyType ->
+                    onBankClick(cardCompanyType)
                 },
             )
         }
@@ -392,7 +392,7 @@ private fun BankSelectRow(
     onBankClick: (CardCompanyType) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val bankList = CardCompanyType.getBankList()
+    val cardCompanyList = CardCompanyType.getBankList()
 
     FlowRow(
         modifier = modifier
@@ -402,19 +402,19 @@ private fun BankSelectRow(
         verticalArrangement = Arrangement.spacedBy(23.dp),
         maxItemsInEachRow = 4
     ) {
-        bankList.forEach { bankType ->
+        cardCompanyList.forEach { cardCompanyType ->
 
-            if (bankType.bankImageRes == null) {
+            if (cardCompanyType.cardCompanyImageRes == null) {
                 return@forEach
             }
 
             BankItem(
-                bankName = stringResource(bankType.bankNameResId),
-                bankImage = painterResource(bankType.bankImageRes),
+                cardCompanyName = stringResource(cardCompanyType.cardCompanyNameResId),
+                cardCompanyImage = painterResource(cardCompanyType.cardCompanyImageRes),
                 modifier = modifier
                     .width(80.dp)
                     .clickable(
-                        onClick = { onBankClick(bankType) },
+                        onClick = { onBankClick(cardCompanyType) },
                         indication = null,
                         interactionSource = remember { MutableInteractionSource() }
                     )
@@ -425,8 +425,8 @@ private fun BankSelectRow(
 
 @Composable
 private fun BankItem(
-    bankName: String,
-    bankImage: Painter,
+    cardCompanyName: String,
+    cardCompanyImage: Painter,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -434,13 +434,13 @@ private fun BankItem(
         modifier = modifier
     ) {
         Image(
-            painter = bankImage,
+            painter = cardCompanyImage,
             contentDescription = "Bank Logo",
             modifier = Modifier.size(Dimensions.LogoDefaults),
         )
         Spacer(modifier = Modifier.height(10.dp))
         Text(
-            text = "${bankName}카드",
+            text = "${cardCompanyName}카드",
             fontSize = 16.sp,
             fontWeight = FontWeight.W500,
         )
@@ -451,8 +451,8 @@ private fun BankItem(
 @Composable
 private fun BankItemPreview() {
     BankItem(
-        bankName = "BC",
-        bankImage = painterResource(R.drawable.bc),
+        cardCompanyName = "BC",
+        cardCompanyImage = painterResource(R.drawable.bc),
     )
 }
 

--- a/app/src/main/java/nextstep/payments/ui/screen/NewCardScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/screen/NewCardScreen.kt
@@ -33,7 +33,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.painter.Painter
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
@@ -46,6 +45,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import nextstep.payments.R
 import nextstep.payments.ui.CardCompanyType
@@ -56,6 +56,7 @@ import nextstep.payments.ui.theme.Dimensions
 import nextstep.payments.ui.utils.CardNumberVisualTransformation
 import nextstep.payments.ui.utils.ExpiryDateVisualTransformation
 import nextstep.payments.ui.viewmodel.NewCardViewModel
+import nextstep.payments.ui.viewmodel.SaveState
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -65,8 +66,6 @@ fun NewCardScreen(
     modifier: Modifier = Modifier,
     viewModel: NewCardViewModel = viewModel(),
 ) {
-    val context = LocalContext.current
-
     val cardNumber by viewModel.cardNumber.collectAsStateWithLifecycle()
     val expiredDate by viewModel.expiredDate.collectAsStateWithLifecycle()
     val ownerName by viewModel.ownerName.collectAsStateWithLifecycle()
@@ -83,8 +82,19 @@ fun NewCardScreen(
 
     // 스낵바 상태 저장
     val snackbarHostState = remember { SnackbarHostState() }
-    val snackbarMessage = remember { context.getString(R.string.validate_modify_snack_bar_message) }
     val coroutineScope = rememberCoroutineScope()
+
+    val snackbarMessage = if (cardId == null) {
+        stringResource(R.string.validate_snack_bar_message)
+    } else {
+        stringResource(R.string.validate_modify_snack_bar_message)
+    }
+
+    val appBarTitle = if (cardId == null) {
+        stringResource(R.string.card_add_app_bar_title)
+    } else {
+        stringResource(R.string.card_update_app_bar_title)
+    }
 
     LaunchedEffect(Unit) {
         if (cardId != null) {
@@ -100,27 +110,63 @@ fun NewCardScreen(
     }
 
     LaunchedEffect(Unit) {
-        viewModel.updateCardState.collect { isUpdatable ->
+        viewModel.updateCardState.collectLatest { isUpdatable ->
             if (!isUpdatable) {
                 coroutineScope.launch {
                     snackbarHostState.showSnackbar(snackbarMessage)
                 }
 
-                return@collect
+                return@collectLatest
             }
 
             navigateToCardList()
         }
     }
 
+    LaunchedEffect(Unit) {
+        viewModel.saveState.collectLatest { state ->
+            when (state) {
+                is SaveState.UpdateCard -> {
+                    cardId?.let {
+                        viewModel.updateCard(
+                            cardId = it,
+                            cardNumber = cardNumber,
+                            expiredDate = expiredDate,
+                            ownerName = ownerName,
+                            password = password,
+                            cardCompanyType = selectedCardCompany
+                        )
+                    }
+                }
+
+                is SaveState.SaveNewCard -> {
+                    viewModel.addCard(
+                        cardNumber = cardNumber,
+                        expiredDate = expiredDate,
+                        ownerName = ownerName,
+                        password = password,
+                        cardCompanyType = selectedCardCompany
+                    )
+
+                    navigateToCardList()
+                }
+
+                is SaveState.ShowSnackbar -> {
+                    coroutineScope.launch {
+                        snackbarHostState.showSnackbar(snackbarMessage)
+                    }
+                }
+            }
+        }
+    }
+
     NewCardScreen(
-        cardId = cardId,
+        appBarTitle = appBarTitle,
         cardNumber = cardNumber,
         expiredDate = expiredDate,
         ownerName = ownerName,
         password = password,
         selectedCardCompany = selectedCardCompany,
-        isSaveEnabled = isSaveEnabled,
         setCardNumber = viewModel::setCardNumber,
         setExpiredDate = viewModel::setExpiredDate,
         setOwnerName = viewModel::setOwnerName,
@@ -128,29 +174,7 @@ fun NewCardScreen(
         snackbarHostState = snackbarHostState,
         onBackCLick = navigateToCardList,
         onSaveClick = {
-            viewModel.addCard(
-                cardNumber = cardNumber,
-                expiredDate = expiredDate,
-                ownerName = ownerName,
-                password = password,
-                cardCompanyType = selectedCardCompany
-            )
-
-            navigateToCardList()
-        },
-        onUpdateClick = {
-            if (cardId == null) {
-                return@NewCardScreen
-            }
-
-            viewModel.updateCard(
-                cardId = cardId,
-                cardNumber = cardNumber,
-                expiredDate = expiredDate,
-                ownerName = ownerName,
-                password = password,
-                cardCompanyType = selectedCardCompany
-            )
+            viewModel.onSaveClick(cardId, isSaveEnabled)
         },
         modifier = modifier
     )
@@ -172,13 +196,12 @@ fun NewCardScreen(
 
 @Composable
 private fun NewCardScreen(
-    cardId: String?,
+    appBarTitle: String,
     cardNumber: String,
     expiredDate: String,
     ownerName: String,
     password: String,
     selectedCardCompany: CardCompanyType?,
-    isSaveEnabled: Boolean,
     snackbarHostState: SnackbarHostState,
     setCardNumber: (String) -> Unit,
     setExpiredDate: (String) -> Unit,
@@ -186,40 +209,16 @@ private fun NewCardScreen(
     setPassword: (String) -> Unit,
     onBackCLick: () -> Unit,
     onSaveClick: () -> Unit,
-    onUpdateClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val context = LocalContext.current
-    val snackbarMessage = remember { context.getString(R.string.validate_snack_bar_message) }
-
-    val coroutineScope = rememberCoroutineScope()
-
-    val appBarTitle = if (cardId == null) {
-        stringResource(R.string.card_add_app_bar_title)
-    } else {
-        stringResource(R.string.card_update_app_bar_title)
-    }
 
     Scaffold(
         topBar = {
             NewCardTopBar(
                 appbarTitle = appBarTitle,
                 onBackClick = onBackCLick,
-                onSaveClick = {
-                    if (cardId != null && isSaveEnabled) {
-                        onUpdateClick()
-                        return@NewCardTopBar
-                    }
-
-                    if (isSaveEnabled) {
-                        onSaveClick()
-                        return@NewCardTopBar
-                    }
-
-                    coroutineScope.launch {
-                        snackbarHostState.showSnackbar(snackbarMessage)
-                    }
-                })
+                onSaveClick = onSaveClick,
+            )
         },
         snackbarHost = {
             SnackbarHost(
@@ -521,12 +520,11 @@ private fun StatefulNewCardScreenPreview() {
 @Composable
 private fun StatelessNewCardScreenPreView() {
     NewCardScreen(
-        cardId = null,
+        appBarTitle = "카드 추가",
         cardNumber = "1234567812345678",
         expiredDate = "12 / 34",
         ownerName = "홍길동",
         password = "1234",
-        isSaveEnabled = true,
         selectedCardCompany = CardCompanyType.BC,
         snackbarHostState = SnackbarHostState(),
         setCardNumber = {},
@@ -535,6 +533,5 @@ private fun StatelessNewCardScreenPreView() {
         setPassword = {},
         onBackCLick = {},
         onSaveClick = {},
-        onUpdateClick = {},
     )
 }

--- a/app/src/main/java/nextstep/payments/ui/screen/NewCardScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/screen/NewCardScreen.kt
@@ -48,7 +48,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import kotlinx.coroutines.launch
 import nextstep.payments.R
-import nextstep.payments.ui.BankType
+import nextstep.payments.ui.CardCompanyType
 import nextstep.payments.ui.screen.component.NewCardTopBar
 import nextstep.payments.ui.screen.component.OutlinedInputTextField
 import nextstep.payments.ui.screen.component.PaymentCard
@@ -82,12 +82,12 @@ fun NewCardScreen(
     val snackbarHostState = remember { SnackbarHostState() }
 
     LaunchedEffect(selectedBank) {
-        if (selectedBank == BankType.NOT_SELECTED) {
+        if (selectedBank == CardCompanyType.NOT_SELECTED) {
             isBottomSheetVisible = true
             sheetState.show()
         }
 
-        if (selectedBank != BankType.NOT_SELECTED) {
+        if (selectedBank != CardCompanyType.NOT_SELECTED) {
             isBottomSheetVisible = false
             sheetState.hide()
         }
@@ -112,7 +112,7 @@ fun NewCardScreen(
                 expiredDate = expiredDate,
                 ownerName = ownerName,
                 password = password,
-                bankType = selectedBank
+                cardCompanyType = selectedBank
             )
             navigateToCardList()
         },
@@ -134,7 +134,7 @@ private fun NewCardScreen(
     expiredDate: String,
     ownerName: String,
     password: String,
-    selectedBank: BankType,
+    selectedBank: CardCompanyType,
     isSaveEnabled: Boolean,
     snackbarHostState: SnackbarHostState,
     setCardNumber: (String) -> Unit,
@@ -293,7 +293,7 @@ private fun PasswordInputField(
 @Composable
 private fun BankBottomModalSheet(
     sheetState: SheetState,
-    onBankClick: (BankType) -> Unit,
+    onBankClick: (CardCompanyType) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     ModalBottomSheet(
@@ -322,10 +322,10 @@ private fun BankBottomModalSheet(
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun BankSelectRow(
-    onBankClick: (BankType) -> Unit,
+    onBankClick: (CardCompanyType) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val bankList = BankType.getBankList()
+    val bankList = CardCompanyType.getBankList()
 
     FlowRow(
         modifier = modifier
@@ -456,7 +456,7 @@ private fun StatelessNewCardScreenPreView() {
         ownerName = "홍길동",
         password = "1234",
         isSaveEnabled = true,
-        selectedBank = BankType.BC,
+        selectedBank = CardCompanyType.BC,
         snackbarHostState = SnackbarHostState(),
         setCardNumber = {},
         setExpiredDate = {},

--- a/app/src/main/java/nextstep/payments/ui/screen/NewCardScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/screen/NewCardScreen.kt
@@ -84,12 +84,14 @@ fun NewCardScreen(
     val snackbarHostState = remember { SnackbarHostState() }
     val coroutineScope = rememberCoroutineScope()
 
+    // 스낵바 메시지
     val snackbarMessage = if (cardId == null) {
         stringResource(R.string.validate_snack_bar_message)
     } else {
         stringResource(R.string.validate_modify_snack_bar_message)
     }
 
+    // 앱바 타이틀
     val appBarTitle = if (cardId == null) {
         stringResource(R.string.card_add_app_bar_title)
     } else {
@@ -127,27 +129,10 @@ fun NewCardScreen(
         viewModel.saveState.collectLatest { state ->
             when (state) {
                 is SaveState.UpdateCard -> {
-                    cardId?.let {
-                        viewModel.updateCard(
-                            cardId = it,
-                            cardNumber = cardNumber,
-                            expiredDate = expiredDate,
-                            ownerName = ownerName,
-                            password = password,
-                            cardCompanyType = selectedCardCompany
-                        )
-                    }
+
                 }
 
                 is SaveState.SaveNewCard -> {
-                    viewModel.addCard(
-                        cardNumber = cardNumber,
-                        expiredDate = expiredDate,
-                        ownerName = ownerName,
-                        password = password,
-                        cardCompanyType = selectedCardCompany
-                    )
-
                     navigateToCardList()
                 }
 

--- a/app/src/main/java/nextstep/payments/ui/screen/component/NewTopBar.kt
+++ b/app/src/main/java/nextstep/payments/ui/screen/component/NewTopBar.kt
@@ -17,14 +17,17 @@ import nextstep.payments.R
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun NewCardTopBar(
+    appbarTitle: String,
     onBackClick: () -> Unit,
     onSaveClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     TopAppBar(
-        title = { Text(
-            stringResource(R.string.card_add_app_bar_title)
-        ) },
+        title = {
+            Text(
+                text = appbarTitle
+            )
+        },
         navigationIcon = {
             IconButton(onClick = { onBackClick() }) {
                 Icon(
@@ -49,6 +52,7 @@ fun NewCardTopBar(
 @Composable
 private fun NewCardTopBarPreview() {
     NewCardTopBar(
+        appbarTitle = "카드 추가",
         onBackClick = { },
         onSaveClick = { },
     )

--- a/app/src/main/java/nextstep/payments/ui/screen/component/PaymentCard.kt
+++ b/app/src/main/java/nextstep/payments/ui/screen/component/PaymentCard.kt
@@ -30,7 +30,7 @@ import nextstep.payments.ui.theme.Dimensions.CardRatioDefaults
 
 @Composable
 fun PaymentCard(
-    bankName: String,
+    cardCompanyName: String,
     cardNumber: String,
     expiredDate: String,
     ownerName: String,
@@ -52,7 +52,7 @@ fun PaymentCard(
             modifier = Modifier.padding(horizontal = 14.dp)
         ) {
             Text(
-                text = "${bankName}카드",
+                text = "${cardCompanyName}카드",
                 fontSize = 12.sp,
                 fontWeight = FontWeight.W500,
                 color = Color.White
@@ -183,7 +183,7 @@ private fun DividerPreview() {
 @Composable
 private fun PaymentCardPreview() {
     PaymentCard(
-        bankName = "신한",
+        cardCompanyName = "신한",
         cardNumber = "1234123412341324",
         expiredDate = "1234",
         ownerName = "홍길동",

--- a/app/src/main/java/nextstep/payments/ui/screen/component/PaymentCard.kt
+++ b/app/src/main/java/nextstep/payments/ui/screen/component/PaymentCard.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.unit.sp
 import nextstep.payments.ui.utils.TextFormatUtil
 import nextstep.payments.R
 import nextstep.payments.ui.theme.Dimensions
+import nextstep.payments.ui.theme.Dimensions.CardRatioDefaults
 
 @Composable
 fun PaymentCard(
@@ -41,7 +42,7 @@ fun PaymentCard(
         modifier = modifier
             .shadow(8.dp)
             .width(Dimensions.CardWidthDefaults)
-            .aspectRatio(52 / 31f)
+            .aspectRatio(CardRatioDefaults)
             .background(
                 color = cardColor,
                 shape = RoundedCornerShape(5.dp),

--- a/app/src/main/java/nextstep/payments/ui/screen/navigation/NavigationRoute.kt
+++ b/app/src/main/java/nextstep/payments/ui/screen/navigation/NavigationRoute.kt
@@ -1,11 +1,24 @@
 package nextstep.payments.ui.screen.navigation
 
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import nextstep.payments.data.model.Card
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 
-sealed class CardRoute {
+@Serializable
+sealed class CardRoute(val route: String) {
     @Serializable
-    data object CardList : CardRoute()
+    data object CardList : CardRoute("cardList")
 
     @Serializable
-    data object NewCard : CardRoute()
+    data object NewCard : CardRoute("newCard") {
+        fun withArgs(card: Card?): String {
+            val json = card?.let { Json.encodeToString(it) } ?: ""
+            return "newCard?card=${json.encodeUrl()}"
+        }
+    }
 }
+
+fun String.encodeUrl(): String = URLEncoder.encode(this, StandardCharsets.UTF_8.toString())

--- a/app/src/main/java/nextstep/payments/ui/screen/navigation/NavigationRoute.kt
+++ b/app/src/main/java/nextstep/payments/ui/screen/navigation/NavigationRoute.kt
@@ -1,11 +1,6 @@
 package nextstep.payments.ui.screen.navigation
 
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.Json
-import nextstep.payments.data.model.Card
-import java.net.URLEncoder
-import java.nio.charset.StandardCharsets
 
 @Serializable
 sealed class CardRoute(val route: String) {
@@ -14,11 +9,9 @@ sealed class CardRoute(val route: String) {
 
     @Serializable
     data object NewCard : CardRoute("newCard") {
-        fun withArgs(card: Card?): String {
-            val json = card?.let { Json.encodeToString(it) } ?: ""
-            return "newCard?card=${json.encodeUrl()}"
+        fun withId(cardId: String?): String {
+            return "newCard?cardId=${cardId}"
         }
     }
 }
 
-fun String.encodeUrl(): String = URLEncoder.encode(this, StandardCharsets.UTF_8.toString())

--- a/app/src/main/java/nextstep/payments/ui/screen/navigation/NavigationRoute.kt
+++ b/app/src/main/java/nextstep/payments/ui/screen/navigation/NavigationRoute.kt
@@ -3,15 +3,12 @@ package nextstep.payments.ui.screen.navigation
 import kotlinx.serialization.Serializable
 
 @Serializable
-sealed class CardRoute(val route: String) {
-    @Serializable
-    data object CardList : CardRoute("cardList")
+sealed class CardRoute {
 
     @Serializable
-    data object NewCard : CardRoute("newCard") {
-        fun withId(cardId: String?): String {
-            return "newCard?cardId=${cardId}"
-        }
-    }
+    data object CardList : CardRoute()
+
+    @Serializable
+    data class NewCard(val cardId: String?) : CardRoute()
 }
 

--- a/app/src/main/java/nextstep/payments/ui/theme/Dimensions.kt
+++ b/app/src/main/java/nextstep/payments/ui/theme/Dimensions.kt
@@ -4,5 +4,6 @@ import androidx.compose.ui.unit.dp
 
 object Dimensions {
     val CardWidthDefaults = 208.dp
+    val CardRatioDefaults = 52 / 31f
     val LogoDefaults = 37.dp
 }

--- a/app/src/main/java/nextstep/payments/ui/viewmodel/NewCardViewModel.kt
+++ b/app/src/main/java/nextstep/payments/ui/viewmodel/NewCardViewModel.kt
@@ -148,15 +148,36 @@ class NewCardViewModel(
     }
 
     fun onSaveClick(cardId: String?, isSaveEnabled: Boolean) {
+
+        // 저장이 불가능한 상태
         if (!isSaveEnabled) {
             _saveState.tryEmit(SaveState.ShowSnackbar)
             return
         }
 
+        // 카드 수정
         if (cardId != null) {
+            updateCard(
+                cardId = cardId,
+                cardNumber = _cardNumber.value,
+                expiredDate = _expiredDate.value,
+                ownerName = _ownerName.value,
+                password = _password.value,
+                cardCompanyType = _selectedCardCompany.value
+            )
+
             _saveState.tryEmit(SaveState.UpdateCard)
             return
         }
+
+        // 새로운 카드 추가
+        addCard(
+            cardNumber = _cardNumber.value,
+            expiredDate = _expiredDate.value,
+            ownerName = _ownerName.value,
+            password = _password.value,
+            cardCompanyType = _selectedCardCompany.value
+        )
 
         _saveState.tryEmit(SaveState.SaveNewCard)
     }

--- a/app/src/main/java/nextstep/payments/ui/viewmodel/NewCardViewModel.kt
+++ b/app/src/main/java/nextstep/payments/ui/viewmodel/NewCardViewModel.kt
@@ -84,4 +84,40 @@ class NewCardViewModel(
             )
         )
     }
+
+    fun getCardById(cardId: String) {
+        val modifyCard = paymentRepsoitory.getCardById(cardId)
+
+        if(modifyCard != null) {
+            _cardNumber.value = modifyCard.cardNumber
+            _expiredDate.value = modifyCard.expiredDate
+            _ownerName.value = modifyCard.ownerName
+            _password.value = modifyCard.password
+            _selectedCardCompany.value = modifyCard.cardCompanyType
+        }
+    }
+
+    fun updateCard(
+        cardId: String,
+        cardNumber: String,
+        expiredDate: String,
+        ownerName: String,
+        password: String,
+        cardCompanyType: CardCompanyType?,
+    ) {
+        if(cardCompanyType == null) {
+            return
+        }
+
+        paymentRepsoitory.updateCard(
+            Card(
+                cardId = cardId,
+                cardNumber = cardNumber,
+                expiredDate = expiredDate,
+                ownerName = ownerName,
+                password = password,
+                cardCompanyType = cardCompanyType
+            )
+        )
+    }
 }

--- a/app/src/main/java/nextstep/payments/ui/viewmodel/NewCardViewModel.kt
+++ b/app/src/main/java/nextstep/payments/ui/viewmodel/NewCardViewModel.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import nextstep.payments.data.model.Card
 import nextstep.payments.data.repository.PaymentCardsRepository
-import nextstep.payments.ui.BankType
+import nextstep.payments.ui.CardCompanyType
 
 class NewCardViewModel(
     private val paymentRepsoitory: PaymentCardsRepository = PaymentCardsRepository,
@@ -27,8 +27,8 @@ class NewCardViewModel(
     private val _password = MutableStateFlow("")
     val password: StateFlow<String> = _password.asStateFlow()
 
-    private val _selectedBank = MutableStateFlow(BankType.NOT_SELECTED)
-    val selectedBank: StateFlow<BankType> = _selectedBank.asStateFlow()
+    private val _selectedBank = MutableStateFlow(CardCompanyType.NOT_SELECTED)
+    val selectedBank: StateFlow<CardCompanyType> = _selectedBank.asStateFlow()
 
     private val _isSaveEnabled = MutableStateFlow(false)
     val isSaveEnabled: StateFlow<Boolean> = _isSaveEnabled.asStateFlow()
@@ -59,8 +59,8 @@ class NewCardViewModel(
         _password.value = password
     }
 
-    fun setSelectedBank(bankType: BankType) {
-        _selectedBank.value = bankType
+    fun setSelectedBank(cardCompanyType: CardCompanyType) {
+        _selectedBank.value = cardCompanyType
     }
 
     fun addCard(
@@ -68,7 +68,7 @@ class NewCardViewModel(
         expiredDate: String,
         ownerName: String,
         password: String,
-        bankType: BankType,
+        cardCompanyType: CardCompanyType,
     ) {
         paymentRepsoitory.addCard(
             Card(
@@ -76,7 +76,7 @@ class NewCardViewModel(
                 expiredDate = expiredDate,
                 ownerName = ownerName,
                 password = password,
-                bankType = bankType
+                cardCompanyType = cardCompanyType
             )
         )
     }

--- a/app/src/main/java/nextstep/payments/ui/viewmodel/NewCardViewModel.kt
+++ b/app/src/main/java/nextstep/payments/ui/viewmodel/NewCardViewModel.kt
@@ -41,9 +41,6 @@ class NewCardViewModel(
     private val _isSaveEnabled = MutableStateFlow(false)
     val isSaveEnabled: StateFlow<Boolean> = _isSaveEnabled.asStateFlow()
 
-    private val _updateCardState = MutableSharedFlow<Boolean>(replay = 1)
-    val updateCardState: SharedFlow<Boolean> = _updateCardState
-
     private val _saveState = MutableSharedFlow<SaveState>(replay = 1)
     val saveState: SharedFlow<SaveState> = _saveState
 
@@ -79,28 +76,6 @@ class NewCardViewModel(
         _selectedCardCompany.value = cardCompanyType
     }
 
-    fun addCard(
-        cardNumber: String,
-        expiredDate: String,
-        ownerName: String,
-        password: String,
-        cardCompanyType: CardCompanyType?,
-    ) {
-        if (cardCompanyType == null) {
-            return
-        }
-
-        paymentRepsoitory.addCard(
-            Card(
-                cardNumber = cardNumber,
-                expiredDate = expiredDate,
-                ownerName = ownerName,
-                password = password,
-                cardCompanyType = cardCompanyType
-            )
-        )
-    }
-
     fun fetchCardById(cardId: String) {
         modifyCard = paymentRepsoitory.getCardById(cardId)
 
@@ -111,40 +86,6 @@ class NewCardViewModel(
             _password.value = card.password
             _selectedCardCompany.value = card.cardCompanyType
         }
-    }
-
-    fun updateCard(
-        cardId: String,
-        cardNumber: String,
-        expiredDate: String,
-        ownerName: String,
-        password: String,
-        cardCompanyType: CardCompanyType?,
-    ) {
-        if (cardCompanyType == null) {
-            return
-        }
-
-        val updatedCard = Card(
-            cardId = cardId,
-            cardNumber = cardNumber,
-            expiredDate = expiredDate,
-            ownerName = ownerName,
-            password = password,
-            cardCompanyType = cardCompanyType
-        )
-
-        if (modifyCard == updatedCard) {
-            _updateCardState.tryEmit(false)
-            return
-        }
-
-        paymentRepsoitory.updateCard(
-            updatedCard = updatedCard
-        )
-
-        // 업데이트 성공
-        _updateCardState.tryEmit(true)
     }
 
     fun onSaveClick(cardId: String?, isSaveEnabled: Boolean) {
@@ -180,5 +121,58 @@ class NewCardViewModel(
         )
 
         _saveState.tryEmit(SaveState.SaveNewCard)
+    }
+
+    private fun addCard(
+        cardNumber: String,
+        expiredDate: String,
+        ownerName: String,
+        password: String,
+        cardCompanyType: CardCompanyType?,
+    ) {
+        if (cardCompanyType == null) {
+            return
+        }
+
+        paymentRepsoitory.addCard(
+            Card(
+                cardNumber = cardNumber,
+                expiredDate = expiredDate,
+                ownerName = ownerName,
+                password = password,
+                cardCompanyType = cardCompanyType
+            )
+        )
+    }
+
+    private fun updateCard(
+        cardId: String,
+        cardNumber: String,
+        expiredDate: String,
+        ownerName: String,
+        password: String,
+        cardCompanyType: CardCompanyType?,
+    ) {
+        if (cardCompanyType == null) {
+            return
+        }
+
+        val updatedCard = Card(
+            cardId = cardId,
+            cardNumber = cardNumber,
+            expiredDate = expiredDate,
+            ownerName = ownerName,
+            password = password,
+            cardCompanyType = cardCompanyType
+        )
+
+        if (modifyCard == updatedCard) {
+            _saveState.tryEmit(SaveState.ShowSnackbar)
+            return
+        }
+
+        paymentRepsoitory.updateCard(
+            updatedCard = updatedCard
+        )
     }
 }

--- a/app/src/main/java/nextstep/payments/ui/viewmodel/NewCardViewModel.kt
+++ b/app/src/main/java/nextstep/payments/ui/viewmodel/NewCardViewModel.kt
@@ -93,7 +93,7 @@ class NewCardViewModel(
         )
     }
 
-    fun getCardById(cardId: String) {
+    fun fetchCardById(cardId: String) {
         modifyCard = paymentRepsoitory.getCardById(cardId)
 
         modifyCard?.let { card ->

--- a/app/src/main/java/nextstep/payments/ui/viewmodel/NewCardViewModel.kt
+++ b/app/src/main/java/nextstep/payments/ui/viewmodel/NewCardViewModel.kt
@@ -27,8 +27,8 @@ class NewCardViewModel(
     private val _password = MutableStateFlow("")
     val password: StateFlow<String> = _password.asStateFlow()
 
-    private val _selectedBank = MutableStateFlow(CardCompanyType.NOT_SELECTED)
-    val selectedBank: StateFlow<CardCompanyType> = _selectedBank.asStateFlow()
+    private val _selectedCardCompany = MutableStateFlow<CardCompanyType?>(null)
+    val selectedCardCompany: StateFlow<CardCompanyType?> = _selectedCardCompany.asStateFlow()
 
     private val _isSaveEnabled = MutableStateFlow(false)
     val isSaveEnabled: StateFlow<Boolean> = _isSaveEnabled.asStateFlow()
@@ -60,7 +60,7 @@ class NewCardViewModel(
     }
 
     fun setSelectedBank(cardCompanyType: CardCompanyType) {
-        _selectedBank.value = cardCompanyType
+        _selectedCardCompany.value = cardCompanyType
     }
 
     fun addCard(
@@ -68,8 +68,12 @@ class NewCardViewModel(
         expiredDate: String,
         ownerName: String,
         password: String,
-        cardCompanyType: CardCompanyType,
+        cardCompanyType: CardCompanyType?,
     ) {
+        if(cardCompanyType == null) {
+            return
+        }
+
         paymentRepsoitory.addCard(
             Card(
                 cardNumber = cardNumber,

--- a/app/src/main/java/nextstep/payments/ui/viewmodel/NewCardViewModel.kt
+++ b/app/src/main/java/nextstep/payments/ui/viewmodel/NewCardViewModel.kt
@@ -1,9 +1,12 @@
 package nextstep.payments.ui.viewmodel
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.launch
 import nextstep.payments.data.model.Card
 import nextstep.payments.data.repository.PaymentCardsRepository
 import nextstep.payments.ui.BankType
@@ -24,11 +27,21 @@ class NewCardViewModel(
     private val _password = MutableStateFlow("")
     val password: StateFlow<String> = _password.asStateFlow()
 
+    private val _selectedBank = MutableStateFlow(BankType.NOT_SELECTED)
+    val selectedBank: StateFlow<BankType> = _selectedBank.asStateFlow()
+
     private val _isSaveEnabled = MutableStateFlow(false)
     val isSaveEnabled: StateFlow<Boolean> = _isSaveEnabled.asStateFlow()
 
-    private val _selectedBank = MutableStateFlow(BankType.NOT_SELECTED)
-    val selectedBank: StateFlow<BankType> = _selectedBank.asStateFlow()
+    init {
+        viewModelScope.launch {
+            combine(cardNumber, expiredDate, password) { card, date, pass ->
+                card.length == 16 && date.length == 4 && pass.length == 4
+            }.collect { valid ->
+                _isSaveEnabled.value = valid
+            }
+        }
+    }
 
     fun setCardNumber(cardNumber: String) {
         _cardNumber.value = cardNumber
@@ -44,11 +57,6 @@ class NewCardViewModel(
 
     fun setPassword(password: String) {
         _password.value = password
-    }
-
-    fun setIsSaveEnabled() {
-        _isSaveEnabled.value =
-            cardNumber.value.length == 16 && expiredDate.value.length == 4 && password.value.length == 4
     }
 
     fun setSelectedBank(bankType: BankType) {

--- a/app/src/main/java/nextstep/payments/ui/viewmodel/NewCardViewModel.kt
+++ b/app/src/main/java/nextstep/payments/ui/viewmodel/NewCardViewModel.kt
@@ -13,6 +13,12 @@ import nextstep.payments.data.model.Card
 import nextstep.payments.data.repository.PaymentCardsRepository
 import nextstep.payments.ui.CardCompanyType
 
+sealed class SaveState {
+    data object UpdateCard : SaveState()
+    data object SaveNewCard : SaveState()
+    data object ShowSnackbar : SaveState()
+}
+
 class NewCardViewModel(
     private val paymentRepsoitory: PaymentCardsRepository = PaymentCardsRepository,
 ) : ViewModel() {
@@ -38,6 +44,8 @@ class NewCardViewModel(
     private val _updateCardState = MutableSharedFlow<Boolean>(replay = 1)
     val updateCardState: SharedFlow<Boolean> = _updateCardState
 
+    private val _saveState = MutableSharedFlow<SaveState>(replay = 1)
+    val saveState: SharedFlow<SaveState> = _saveState
 
     private var modifyCard: Card? = null
 
@@ -137,5 +145,19 @@ class NewCardViewModel(
 
         // 업데이트 성공
         _updateCardState.tryEmit(true)
+    }
+
+    fun onSaveClick(cardId: String?, isSaveEnabled: Boolean) {
+        if (!isSaveEnabled) {
+            _saveState.tryEmit(SaveState.ShowSnackbar)
+            return
+        }
+
+        if (cardId != null) {
+            _saveState.tryEmit(SaveState.UpdateCard)
+            return
+        }
+
+        _saveState.tryEmit(SaveState.SaveNewCard)
     }
 }

--- a/app/src/main/java/nextstep/payments/ui/viewmodel/NewCardViewModel.kt
+++ b/app/src/main/java/nextstep/payments/ui/viewmodel/NewCardViewModel.kt
@@ -1,5 +1,6 @@
 package nextstep.payments.ui.viewmodel
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -32,6 +33,8 @@ class NewCardViewModel(
 
     private val _isSaveEnabled = MutableStateFlow(false)
     val isSaveEnabled: StateFlow<Boolean> = _isSaveEnabled.asStateFlow()
+
+    private var modifyCard: Card? = null
 
     init {
         viewModelScope.launch {
@@ -70,7 +73,7 @@ class NewCardViewModel(
         password: String,
         cardCompanyType: CardCompanyType?,
     ) {
-        if(cardCompanyType == null) {
+        if (cardCompanyType == null) {
             return
         }
 
@@ -86,14 +89,14 @@ class NewCardViewModel(
     }
 
     fun getCardById(cardId: String) {
-        val modifyCard = paymentRepsoitory.getCardById(cardId)
+        modifyCard = paymentRepsoitory.getCardById(cardId)
 
-        if(modifyCard != null) {
-            _cardNumber.value = modifyCard.cardNumber
-            _expiredDate.value = modifyCard.expiredDate
-            _ownerName.value = modifyCard.ownerName
-            _password.value = modifyCard.password
-            _selectedCardCompany.value = modifyCard.cardCompanyType
+        modifyCard?.let { card ->
+            _cardNumber.value = card.cardNumber
+            _expiredDate.value = card.expiredDate
+            _ownerName.value = card.ownerName
+            _password.value = card.password
+            _selectedCardCompany.value = card.cardCompanyType
         }
     }
 
@@ -104,20 +107,29 @@ class NewCardViewModel(
         ownerName: String,
         password: String,
         cardCompanyType: CardCompanyType?,
-    ) {
-        if(cardCompanyType == null) {
-            return
+    ): Boolean {
+        if (cardCompanyType == null) {
+            return false
+        }
+
+        val updatedCard = Card(
+            cardId = cardId,
+            cardNumber = cardNumber,
+            expiredDate = expiredDate,
+            ownerName = ownerName,
+            password = password,
+            cardCompanyType = cardCompanyType
+        )
+
+        if (modifyCard == updatedCard) {
+            Log.d("앙데욧!", "같은 카드입니다.")
+            return false
         }
 
         paymentRepsoitory.updateCard(
-            Card(
-                cardId = cardId,
-                cardNumber = cardNumber,
-                expiredDate = expiredDate,
-                ownerName = ownerName,
-                password = password,
-                cardCompanyType = cardCompanyType
-            )
+            updatedCard = updatedCard
         )
+
+        return true
     }
 }

--- a/app/src/main/java/nextstep/payments/ui/viewmodel/NewCardViewModel.kt
+++ b/app/src/main/java/nextstep/payments/ui/viewmodel/NewCardViewModel.kt
@@ -1,9 +1,10 @@
 package nextstep.payments.ui.viewmodel
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
@@ -33,6 +34,10 @@ class NewCardViewModel(
 
     private val _isSaveEnabled = MutableStateFlow(false)
     val isSaveEnabled: StateFlow<Boolean> = _isSaveEnabled.asStateFlow()
+
+    private val _updateCardState = MutableSharedFlow<Boolean>(replay = 1)
+    val updateCardState: SharedFlow<Boolean> = _updateCardState
+
 
     private var modifyCard: Card? = null
 
@@ -107,9 +112,9 @@ class NewCardViewModel(
         ownerName: String,
         password: String,
         cardCompanyType: CardCompanyType?,
-    ): Boolean {
+    ) {
         if (cardCompanyType == null) {
-            return false
+            return
         }
 
         val updatedCard = Card(
@@ -122,14 +127,15 @@ class NewCardViewModel(
         )
 
         if (modifyCard == updatedCard) {
-            Log.d("앙데욧!", "같은 카드입니다.")
-            return false
+            _updateCardState.tryEmit(false)
+            return
         }
 
         paymentRepsoitory.updateCard(
             updatedCard = updatedCard
         )
 
-        return true
+        // 업데이트 성공
+        _updateCardState.tryEmit(true)
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,13 +27,12 @@
 
     <string name="password_hidden_text">****</string>
 
-    <string name="bank_not_select">OO</string>
-    <string name="bank_bc">BC</string>
-    <string name="bank_shinhan">신한</string>
-    <string name="bank_kakao">카카오</string>
-    <string name="bank_hyundai">현대</string>
-    <string name="bank_woori">우리</string>
-    <string name="bank_lotte">롯데</string>
-    <string name="bank_hana">하나</string>
-    <string name="bank_kb">국민</string>
+    <string name="card_company_bc">BC</string>
+    <string name="card_company_shinhan">신한</string>
+    <string name="card_company_kakao">카카오</string>
+    <string name="card_company_hyundai">현대</string>
+    <string name="card_company_woori">우리</string>
+    <string name="card_company_lotte">롯데</string>
+    <string name="card_company_hana">하나</string>
+    <string name="card_company_kb">국민</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
     <string name="app_bar_add_action_button">추가</string>
     <string name="card_app_title">"Payments"</string>
     <string name="card_add_app_bar_title">카드 추가</string>
+    <string name="card_update_app_bar_title">카드 수정</string>
     <string name="new_card_register_text">새로운 카드를 등록해주세요</string>
     <string name="validate_snack_bar_message">카드 정보를 확인해주세요.</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,6 +7,7 @@
     <string name="card_update_app_bar_title">카드 수정</string>
     <string name="new_card_register_text">새로운 카드를 등록해주세요</string>
     <string name="validate_snack_bar_message">카드 정보를 확인해주세요.</string>
+    <string name="validate_modify_snack_bar_message">수정할 카드 정보를 확인해주세요.</string>
 
     <string name="register_card_icon_content_description">registerCardContainer</string>
     <string name="back_stack_icon_content_description">backStack</string>


### PR DESCRIPTION
### 🚀 4단계 - 페이먼츠(카드 수정)
- 카드 수정 기능을 구현한다.
  - 카드 목록에서 카드를 선택하면 카드 수정 화면으로 이동한다.
  - 카드 수정 화면에서 변경사항이 발생하지 않으면 수정이 불가능하다.
  - 카드가 수정되면 카드 목록 화면에 변경사항이 반영된다.

석준님 안녕하세요~ 4단계 미션이 완료되어 PR 요청드립니다.
요즘 이것저것 일정이 많아서 요청이 늦어졌네요 ㅠㅜ
이전 미션에서 주신 피드백 사항도 곰곰히 생각해보며 열심히 개선해보았습니다.

미션 수행중 궁금했던 사항이 있는데 답변주시면 감사하겠습니다!

**refactor: Navigation 객체 탐색에서 Route 탐색으로 수정 및 카드 목록 클리시 해당 데이터 NewCard…**  ee3132d
카드 수정 로직을 구성하기 위해 Card 객체에 cardId 속성을 추가하였습니다.
카드 목록의 추가되어 있는 카드를 클릭시 해당 카드 객체의 cardId를 카드 등록 화면으로 전달하여 카드 수정 로직을 구성하기 위함이었습니다.
그런데 여기서 기존 Navigation을 통해 화면을 이동하는 방식이 data object 객체를 활용하여 이동하는 로직으로 구성되어있는데 데이터를 넘기기 위해서는 route 방식으로 데이터를 넘기는 방식 밖에 찾지 못해 일단 route 방식으로 수정하여 cardId를 카드 등록 화면으로 넘겼습니다. 혹시 기존 객체를 활용하여 넘기는 방법이 있을가요? 아니면 더 좋은 방법이 있었을가요..?

**feat: NewCardScreen 카드 수정 기능 추가 및 카드 추가 기능과 분기 처리** 3e02577e8eef0d073681347d5d21febc8df71aeb
NewCardScreen에 카드 수정과 카드 추가 기능을 cardId 값의 유무에 따라 분기처리하여 구현해보았습니다.
유사한 화면의 유사한 로직 처리라고 생각되어 따로 화면 분리를 하지않고 하나의 화면에서 두가지 로직을 구현하였는데 석준님이 보시기엔 어떠신지 궁금합니다.

일단 미션 진행 사항 중 궁금했던점은 여기까지입니다.
한번 코드보시고 또 피드백이 필요한 부분이 보인다면 말씀해주시면 감사하겠습니다!