### PR TITLE
🚀 2단계 - 페이먼츠(카드 목록)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,12 +6,12 @@ plugins {
 
 android {
     namespace = "nextstep.payments"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "nextstep.payments"
         minSdk = 26
-        targetSdk = 35
+        targetSdk = 36
         versionCode = 1
         versionName = "1.0"
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -60,6 +60,7 @@ dependencies {
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.constraintlayout.compose)
+    implementation(libs.androidx.material.icons.extended)
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -59,6 +59,8 @@ dependencies {
     implementation(libs.androidx.material3)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.lifecycle.runtime.compose)
+    implementation(libs.androidx.constraintlayout.compose)
+
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/androidTest/java/nextstep/payments/ui/card_list/CardListScreenTest.kt
+++ b/app/src/androidTest/java/nextstep/payments/ui/card_list/CardListScreenTest.kt
@@ -1,0 +1,80 @@
+package nextstep.payments.ui.card_list
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import nextstep.payments.ui.common.model.CreditCard
+import org.junit.Rule
+import org.junit.Test
+
+class CardListScreenTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `등록된_카드가_없으면_카드_등록_안내_문구를_보여준다`() {
+        composeTestRule.setContent {
+            CardListScreen(
+                state = CardListState(
+                    cards = CreditCardUiState.Empty
+                ),
+                navigateToNewCard = {},
+            )
+        }
+
+        composeTestRule
+            .onNodeWithContentDescription("새로운 카드 등록 안내 문구")
+            .assertExists()
+    }
+
+    @Test
+    fun `등록된_카드가_1개_있으면_카드_등록_안내_문구를_보여주지_않는다`() {
+        composeTestRule.setContent {
+            CardListScreen(
+                state = CardListState(
+                    cards = CreditCardUiState.One(
+                        creditCard = CreditCard(
+                            cardNumber = "1111222233334444",
+                            expiredDate = "1212",
+                            ownerName = "홍길동",
+                        )
+                    )
+                ),
+                navigateToNewCard = {},
+            )
+        }
+
+        composeTestRule
+            .onNodeWithContentDescription("새로운 카드 등록 안내 문구")
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun `등록된_카드가_2개_이상_있으면_카드_추가_버튼을_Top_app_bar_에_둔다`() {
+        composeTestRule.setContent {
+            CardListScreen(
+                state = CardListState(
+                    cards = CreditCardUiState.Many(
+                        creditCards = listOf(
+                            CreditCard(
+                                cardNumber = "1111222233334444",
+                                expiredDate = "1212",
+                                ownerName = "홍길동",
+                            ),
+                            CreditCard(
+                                cardNumber = "1111222233334445",
+                                expiredDate = "1212",
+                                ownerName = "홍길동",
+                            )
+                        )
+                    )
+                ),
+                navigateToNewCard = {},
+            )
+        }
+
+        composeTestRule
+            .onNodeWithContentDescription("TopAppBar 카드 추가 버튼")
+            .assertExists()
+    }
+}

--- a/app/src/androidTest/java/nextstep/payments/ui/new_card/NewCardScreenTest.kt
+++ b/app/src/androidTest/java/nextstep/payments/ui/new_card/NewCardScreenTest.kt
@@ -1,0 +1,383 @@
+@file:OptIn(ExperimentalTestApi::class)
+
+package nextstep.payments.ui.new_card
+
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.performTextInputSelection
+import androidx.compose.ui.test.pressKey
+import androidx.compose.ui.text.TextRange
+import org.junit.Rule
+import org.junit.Test
+
+class NewCardScreenTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+
+    @Test
+    fun `카드_번호_포맷팅`() {
+        composeTestRule.setContent {
+            NewCardScreenRoot(
+                navigateToCardList = {},
+            )
+        }
+
+        val node = composeTestRule
+            .onNodeWithContentDescription("카드 번호 입력", useUnmergedTree = true)
+
+        node.performTextInput("1111222233334444")
+
+        node.assertTextEquals("1111-2222-3333-4444")
+    }
+
+    @Test
+    fun `만료일_포맷팅`() {
+        composeTestRule.setContent {
+            NewCardScreenRoot(
+                navigateToCardList = {},
+            )
+        }
+
+        val node = composeTestRule
+            .onNodeWithContentDescription("만료일 입력", useUnmergedTree = true)
+
+        node.performTextInput("1111")
+
+        node.assertTextEquals("11/11")
+    }
+
+    @Test
+    fun `카드_번호를_입력하지_않으면_카드_추가_버튼이_비활성화된다`() {
+        composeTestRule.setContent {
+            NewCardScreenRoot(
+                navigateToCardList = {},
+            )
+        }
+
+        composeTestRule
+            .onNodeWithContentDescription("만료일 입력")
+            .performTextInput("1111")
+
+        composeTestRule
+            .onNodeWithContentDescription("카드 소유자 이름 입력")
+            .performTextInput("홍길동")
+
+        composeTestRule
+            .onNodeWithContentDescription("카드 비밀번호 입력")
+            .performTextInput("1111")
+
+        composeTestRule
+            .onNodeWithContentDescription("카드 추가 버튼")
+            .assertIsNotEnabled()
+    }
+
+    @Test
+    fun `카드_번호를_모두_입력하지_않으면_카드_추가_버튼이_비활성화된다`() {
+        composeTestRule.setContent {
+            NewCardScreenRoot(
+                navigateToCardList = {},
+            )
+        }
+
+        composeTestRule
+            .onNodeWithContentDescription("카드 번호 입력")
+            .performTextInput("111122223333444")
+
+        composeTestRule
+            .onNodeWithContentDescription("만료일 입력")
+            .performTextInput("1111")
+
+        composeTestRule
+            .onNodeWithContentDescription("카드 소유자 이름 입력")
+            .performTextInput("홍길동")
+
+        composeTestRule
+            .onNodeWithContentDescription("카드 비밀번호 입력")
+            .performTextInput("1111")
+
+        composeTestRule
+            .onNodeWithContentDescription("카드 추가 버튼")
+            .assertIsNotEnabled()
+    }
+
+    @Test
+    fun `만료일을_입력하지_않으면_카드_추가_버튼이_비활성화된다`() {
+        composeTestRule.setContent {
+            NewCardScreenRoot(
+                navigateToCardList = {},
+            )
+        }
+
+        composeTestRule
+            .onNodeWithContentDescription("카드 번호 입력")
+            .performTextInput("1111222233334444")
+
+        composeTestRule
+            .onNodeWithContentDescription("카드 소유자 이름 입력")
+            .performTextInput("홍길동")
+
+        composeTestRule
+            .onNodeWithContentDescription("카드 비밀번호 입력")
+            .performTextInput("1111")
+
+        composeTestRule
+            .onNodeWithContentDescription("카드 추가 버튼")
+            .assertIsNotEnabled()
+    }
+
+    @Test
+    fun `만료일을_모두_입력하지_않으면_카드_추가_버튼이_비활성화된다`() {
+        composeTestRule.setContent {
+            NewCardScreenRoot(
+                navigateToCardList = {},
+            )
+        }
+
+        composeTestRule
+            .onNodeWithContentDescription("카드 번호 입력")
+            .performTextInput("1111222233334444")
+
+        composeTestRule
+            .onNodeWithContentDescription("만료일 입력")
+            .performTextInput("111")
+
+        composeTestRule
+            .onNodeWithContentDescription("카드 소유자 이름 입력")
+            .performTextInput("홍길동")
+
+        composeTestRule
+            .onNodeWithContentDescription("카드 비밀번호 입력")
+            .performTextInput("1111")
+
+        composeTestRule
+            .onNodeWithContentDescription("카드 추가 버튼")
+            .assertIsNotEnabled()
+    }
+
+    @Test
+    fun `만료일을_잘못_입력하면_카드_추가_버튼이_비활성화된다`() {
+        composeTestRule.setContent {
+            NewCardScreenRoot(
+                navigateToCardList = {},
+            )
+        }
+
+        composeTestRule
+            .onNodeWithContentDescription("카드 번호 입력")
+            .performTextInput("1111222233334444")
+
+        composeTestRule
+            .onNodeWithContentDescription("만료일 입력")
+            .performTextInput("1777")
+
+        composeTestRule
+            .onNodeWithContentDescription("카드 소유자 이름 입력")
+            .performTextInput("홍길동")
+
+        composeTestRule
+            .onNodeWithContentDescription("카드 비밀번호 입력")
+            .performTextInput("1111")
+
+        composeTestRule
+            .onNodeWithContentDescription("카드 추가 버튼")
+            .assertIsNotEnabled()
+    }
+
+    @Test
+    fun `카드_소유자_이름을_입력하지_않아도_카드_추가_버튼이_활성화된다`() {
+        composeTestRule.setContent {
+            NewCardScreenRoot(
+                navigateToCardList = {},
+            )
+        }
+
+        composeTestRule
+            .onNodeWithContentDescription("카드 번호 입력")
+            .performTextInput("1111222233334444")
+
+        composeTestRule
+            .onNodeWithContentDescription("만료일 입력")
+            .performTextInput("1212")
+
+        composeTestRule
+            .onNodeWithContentDescription("카드 비밀번호 입력")
+            .performTextInput("1111")
+
+        composeTestRule
+            .onNodeWithContentDescription("카드 추가 버튼")
+            .assertIsEnabled()
+    }
+
+    @Test
+    fun `카드_비밀번호를_입력하지_않으면_카드_추가_버튼이_비활성화된다`() {
+        composeTestRule.setContent {
+            NewCardScreenRoot(
+                navigateToCardList = {},
+            )
+        }
+
+        composeTestRule
+            .onNodeWithContentDescription("카드 번호 입력")
+            .performTextInput("1111222233334444")
+
+        composeTestRule
+            .onNodeWithContentDescription("만료일 입력")
+            .performTextInput("1212")
+
+        composeTestRule
+            .onNodeWithContentDescription("카드 소유자 이름 입력")
+            .performTextInput("홍길동")
+
+        composeTestRule
+            .onNodeWithContentDescription("카드 추가 버튼")
+            .assertIsNotEnabled()
+    }
+
+    @Test
+    fun `카드_비밀번호를_모두_입력하지_않으면_카드_추가_버튼이_비활성화된다`() {
+        composeTestRule.setContent {
+            NewCardScreenRoot(
+                navigateToCardList = {},
+            )
+        }
+
+        composeTestRule
+            .onNodeWithContentDescription("카드 번호 입력")
+            .performTextInput("1111222233334444")
+
+        composeTestRule
+            .onNodeWithContentDescription("만료일 입력")
+            .performTextInput("1212")
+
+        composeTestRule
+            .onNodeWithContentDescription("카드 소유자 이름 입력")
+            .performTextInput("홍길동")
+
+        composeTestRule
+            .onNodeWithContentDescription("카드 비밀번호 입력")
+            .performTextInput("111")
+
+        composeTestRule
+            .onNodeWithContentDescription("카드 추가 버튼")
+            .assertIsNotEnabled()
+    }
+
+    @Test
+    fun `카드_만료일을_포맷에_맞게_입력하지_않으면_입력이_안된다`() {
+        composeTestRule.setContent {
+            NewCardScreenRoot(
+                navigateToCardList = {},
+            )
+        }
+
+        // useUnmergedTree를 true로 설정하지 않으면 `assertTextEquals`로 값을 검증할 수 없음
+        val node = composeTestRule
+            .onNodeWithContentDescription(label = "만료일 입력", useUnmergedTree = true)
+
+        // ViewModel에서 입력된 값이 포맷에 맞는지 검증하고, 일치하지 않으면 반영하지 않고 있습니다.
+        // 1999를 입력하면 포맷에 맞지 않아 1 또한 입력되지 않기 때문에, 실제로 입력하는 것처럼 개별적으로 입력해줬습니다.
+        node.performClick()
+        node.performTextInput("1")
+        node.performTextInput("9")
+        node.performTextInput("9")
+        node.performTextInput("9")
+
+        node.assertTextEquals("1")
+    }
+
+    @Test
+    fun `카드_만료일에서_값을_수정할때_포맷에_맞지_않으면_무시한다`() {
+        composeTestRule.setContent {
+            NewCardScreenRoot(
+                navigateToCardList = {},
+            )
+        }
+
+        val node = composeTestRule
+            .onNodeWithContentDescription(label = "만료일 입력", useUnmergedTree = true)
+
+        node.performClick()
+        node.performTextInput("1")
+        node.performTextInput("1")
+        node.performTextInput("7")
+        node.performTextInput("9")
+
+        // 커서를 7 앞으로 옮깁니다.
+        node.performTextInputSelection(TextRange(2))
+
+        // https://stackoverflow.com/a/78985901/11722881
+        node.performKeyInput {
+            pressKey(Key.Backspace)
+        }
+
+        node.assertTextEquals("11/79")
+    }
+
+    @Test
+    fun `카드_만료일에서_값을_수정할때_포맷에_맞으면_반영한다`() {
+        composeTestRule.setContent {
+            NewCardScreenRoot(
+                navigateToCardList = {},
+            )
+        }
+
+        val node = composeTestRule
+            .onNodeWithContentDescription(label = "만료일 입력", useUnmergedTree = true)
+
+        node.performClick()
+        node.performTextInput("1")
+        node.performTextInput("1")
+        node.performTextInput("2")
+        node.performTextInput("9")
+
+        // 커서를 2 앞으로 옮깁니다.
+        node.performTextInputSelection(TextRange(2))
+
+        // https://stackoverflow.com/a/78985901/11722881
+        node.performKeyInput {
+            pressKey(Key.Backspace)
+        }
+
+        node.assertTextEquals("12/9")
+    }
+
+    @Test
+    fun `모두_포맷에_맞게_입력하면_카드_추가_버튼이_활성화된다`() {
+        composeTestRule.setContent {
+            NewCardScreenRoot(
+                navigateToCardList = {},
+            )
+        }
+
+        composeTestRule
+            .onNodeWithContentDescription("카드 번호 입력")
+            .performTextInput("1111222233334444")
+
+        composeTestRule
+            .onNodeWithContentDescription("만료일 입력")
+            .performTextInput("1212")
+
+        composeTestRule
+            .onNodeWithContentDescription("카드 소유자 이름 입력")
+            .performTextInput("홍길동")
+
+        composeTestRule
+            .onNodeWithContentDescription("카드 비밀번호 입력")
+            .performTextInput("1111")
+
+        composeTestRule
+            .onNodeWithContentDescription("카드 추가 버튼")
+            .assertIsEnabled()
+    }
+
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,7 +15,6 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:label="@string/app_name"
             android:theme="@style/Theme.Payments">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -23,6 +22,7 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity android:name=".ui.new_card.NewCardActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/java/nextstep/payments/MainActivity.kt
+++ b/app/src/main/java/nextstep/payments/MainActivity.kt
@@ -14,7 +14,7 @@ import nextstep.payments.ui.theme.PaymentsTheme
 
 class MainActivity : ComponentActivity() {
 
-    private val viewModel by viewModels<CardListViewModel>()
+    private val viewModel by viewModels<CardListViewModel> { CardListViewModel.Factory }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/nextstep/payments/MainActivity.kt
+++ b/app/src/main/java/nextstep/payments/MainActivity.kt
@@ -1,17 +1,40 @@
 package nextstep.payments
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
-import nextstep.payments.ui.new_card.NewCardScreen
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.activity.viewModels
+import nextstep.payments.ui.card_list.CardListScreenRoot
+import nextstep.payments.ui.card_list.CardListViewModel
+import nextstep.payments.ui.new_card.NewCardActivity
 import nextstep.payments.ui.theme.PaymentsTheme
 
 class MainActivity : ComponentActivity() {
+
+    private val viewModel by viewModels<CardListViewModel>()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
         setContent {
+            val launcher =
+                rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+                    if (it.resultCode == RESULT_OK) {
+                        viewModel.fetchCards()
+                    }
+                }
+
             PaymentsTheme {
-                NewCardScreen()
+                CardListScreenRoot(
+                    viewModel = viewModel,
+                    navigateToNewCard = {
+                        val intent = Intent(this, NewCardActivity::class.java)
+                        launcher.launch(intent)
+                    }
+                )
             }
         }
     }

--- a/app/src/main/java/nextstep/payments/common/ObserveAsEvents.kt
+++ b/app/src/main/java/nextstep/payments/common/ObserveAsEvents.kt
@@ -1,0 +1,28 @@
+package nextstep.payments.common
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.repeatOnLifecycle
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.withContext
+
+@Composable
+fun <T>ObserveAsEvents(
+    flow: Flow<T>,
+    key1: Any? = null,
+    key2: Any? = null,
+    onEvent: (T) -> Unit,
+) {
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    LaunchedEffect(flow, lifecycleOwner.lifecycle, key1, key2) {
+        lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            withContext(Dispatchers.Main.immediate) {
+                flow.collect(onEvent)
+            }
+        }
+    }
+}

--- a/app/src/main/java/nextstep/payments/common/ObserveAsEvents.kt
+++ b/app/src/main/java/nextstep/payments/common/ObserveAsEvents.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.withContext
 
 @Composable
-fun <T>ObserveAsEvents(
+fun <T> ObserveAsEvents(
     flow: Flow<T>,
     key1: Any? = null,
     key2: Any? = null,

--- a/app/src/main/java/nextstep/payments/data/card/CardEntity.kt
+++ b/app/src/main/java/nextstep/payments/data/card/CardEntity.kt
@@ -1,0 +1,8 @@
+package nextstep.payments.data.card
+
+data class CardEntity(
+    val cardNumber: String = "",
+    val expiredDate: String = "",
+    val ownerName: String = "",
+    val password: String = "",
+)

--- a/app/src/main/java/nextstep/payments/data/card/PaymentCardRepository.kt
+++ b/app/src/main/java/nextstep/payments/data/card/PaymentCardRepository.kt
@@ -6,7 +6,13 @@ object PaymentCardRepository {
     val cards: List<CardEntity>
         get() = _cards.toList()
 
-    fun addCard(cardEntity: CardEntity) {
+    fun addCard(cardEntity: CardEntity): Boolean {
+        // 카드를 등록하기 전에 이미 등록된 카드 번호인지 확인합니다.
+        // LazyList에서 key를 카드번호로 설정해뒀는데, 중복된 key를 가진 데이터가 있으면 에러가 발생해서 추가했습니다.
+        if (_cards.any { it.cardNumber == cardEntity.cardNumber }) {
+            return false
+        }
         _cards.add(cardEntity)
+        return true
     }
 }

--- a/app/src/main/java/nextstep/payments/data/card/PaymentCardRepository.kt
+++ b/app/src/main/java/nextstep/payments/data/card/PaymentCardRepository.kt
@@ -1,0 +1,12 @@
+package nextstep.payments.data.card
+
+object PaymentCardRepository {
+
+    private val _cards = mutableListOf<CardEntity>()
+    val cards: List<CardEntity>
+        get() = _cards.toList()
+
+    fun addCard(cardEntity: CardEntity) {
+        _cards.add(cardEntity)
+    }
+}

--- a/app/src/main/java/nextstep/payments/ui/card_list/CardListScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/card_list/CardListScreen.kt
@@ -144,7 +144,7 @@ fun CardListScreen(
     }
 }
 
-public class CardListScreenPreviewParameterProvider : PreviewParameterProvider<CardListState> {
+class CardListScreenPreviewParameterProvider : PreviewParameterProvider<CardListState> {
     override val values: Sequence<CardListState>
         get() = sequenceOf(
             CardListState(

--- a/app/src/main/java/nextstep/payments/ui/card_list/CardListScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/card_list/CardListScreen.kt
@@ -15,7 +15,7 @@ import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.TopAppBarDefaults.topAppBarColors
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -76,8 +76,8 @@ fun CardListScreen(
                         )
                     }
                 },
-                colors = TopAppBarDefaults.topAppBarColors().copy(
-                    containerColor = Color.White
+                colors = topAppBarColors(
+                    containerColor = Color.White,
                 )
             )
         }

--- a/app/src/main/java/nextstep/payments/ui/card_list/CardListScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/card_list/CardListScreen.kt
@@ -1,5 +1,10 @@
 package nextstep.payments.ui.card_list
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 
@@ -9,5 +14,28 @@ fun CardListScreenRoot(
     navigateToNewCard: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    CardListScreen(
+        navigateToNewCard = navigateToNewCard,
+        modifier = modifier,
+    )
+}
 
+@Composable
+fun CardListScreen(
+    navigateToNewCard: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier,
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier.padding(innerPadding),
+        ) {
+            Button(
+                onClick = navigateToNewCard,
+            ) {
+                Text("카드 추가 화면으로 이동")
+            }
+        }
+    }
 }

--- a/app/src/main/java/nextstep/payments/ui/card_list/CardListScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/card_list/CardListScreen.kt
@@ -1,12 +1,35 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
 package nextstep.payments.ui.card_list
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Button
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import nextstep.payments.R
+import nextstep.payments.ui.common.model.CreditCard
+import nextstep.payments.ui.components.PaymentCard
+import nextstep.payments.ui.components.PaymentCardAdd
+import nextstep.payments.ui.theme.PaymentsTheme
 
 @Composable
 fun CardListScreenRoot(
@@ -14,7 +37,10 @@ fun CardListScreenRoot(
     navigateToNewCard: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val state = viewModel.state.collectAsStateWithLifecycle()
+
     CardListScreen(
+        state = state.value,
         navigateToNewCard = navigateToNewCard,
         modifier = modifier,
     )
@@ -22,20 +48,147 @@ fun CardListScreenRoot(
 
 @Composable
 fun CardListScreen(
+    state: CardListState,
     navigateToNewCard: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Scaffold(
         modifier = modifier,
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = {
+                    Text(stringResource(R.string.card_list_title))
+                },
+                actions = {
+                    if (state.cards is CreditCardUiState.Many) {
+                        Text(
+                            text = stringResource(R.string.card_list_add_new_card_top_bar),
+                            fontWeight = FontWeight.W700,
+                            fontSize = 18.sp,
+                            modifier = Modifier
+                                .padding(end = 16.dp)
+                                .clickable {
+                                    navigateToNewCard()
+                                },
+                        )
+                    }
+                }
+            )
+        }
     ) { innerPadding ->
         Column(
-            modifier = Modifier.padding(innerPadding),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier
+                .padding(innerPadding)
+                .fillMaxSize(),
         ) {
-            Button(
-                onClick = navigateToNewCard,
-            ) {
-                Text("카드 추가 화면으로 이동")
+            /**
+             * 각 상황에 따른 UI를 미리 분리해 두는 것이 요구사항이 변경되었을 때 더 대응하기 쉽다고 생각해 when 절을 사용했습니다.
+             * Compound Component 패턴을 적용해야 할지 고민해봤는데, 적용해야 하는 이유와 어떻게 적용할지를 떠올리지 못했습니다.
+             * https://wisemuji.medium.com/jetpack-compose-ui-%EC%A1%B0%ED%95%A9-composition-%ED%95%98%EA%B8%B0-%EC%8B%AC%ED%99%94-33910e8f09df
+             */
+            when (val cards = state.cards) {
+                CreditCardUiState.Empty -> {
+                    Text(
+                        text = stringResource(R.string.card_list_add_new_card),
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 18.sp,
+                        modifier = Modifier
+                            .padding(vertical = 32.dp)
+                    )
+                    PaymentCardAdd(
+                        modifier = Modifier.clickable {
+                            navigateToNewCard()
+                        }
+                    )
+                }
+
+                is CreditCardUiState.Many -> {
+                    LazyColumn(
+                        verticalArrangement = Arrangement.spacedBy(32.dp),
+                    ) {
+                        items(
+                            items = cards.creditCards,
+                            key = {
+                                it.cardNumber
+                            }
+                        ) {
+                            PaymentCard(
+                                cardInfo = it,
+                            )
+                        }
+                    }
+                }
+
+                is CreditCardUiState.One -> {
+                    PaymentCard(
+                        cardInfo = cards.creditCard
+                    )
+                    Spacer(modifier = Modifier.padding(bottom = 32.dp))
+                    PaymentCardAdd(
+                        modifier = Modifier.clickable {
+                            navigateToNewCard()
+                        }
+                    )
+                }
             }
+
         }
+    }
+}
+
+public class CardListScreenPreviewParameterProvider : PreviewParameterProvider<CardListState> {
+    override val values: Sequence<CardListState>
+        get() = sequenceOf(
+            CardListState(
+                cards = CreditCardUiState.Empty,
+            ),
+            CardListState(
+                cards = CreditCardUiState.One(
+                    creditCard = CreditCard(
+                        cardNumber = "1111111111111111",
+                        expiredDate = "0000",
+                        ownerName = "홍길동",
+                        password = "0000",
+                    )
+                )
+            ),
+            CardListState(
+                cards = CreditCardUiState.Many(
+                    creditCards = listOf(
+                        CreditCard(
+                            cardNumber = "4111-1111-1111-1111",
+                            expiredDate = "12/27",
+                            ownerName = "Kim Minsoo",
+                            password = "1234"
+                        ),
+                        CreditCard(
+                            cardNumber = "5500-0000-0000-0004",
+                            expiredDate = "07/26",
+                            ownerName = "Lee Hana",
+                            password = "5678"
+                        ),
+                        CreditCard(
+                            cardNumber = "3400-000000-00009",
+                            expiredDate = "03/28",
+                            ownerName = "Park Jiwon",
+                            password = "9876"
+                        )
+                    )
+                )
+            )
+        )
+}
+
+@Preview
+@Composable
+private fun CardListScreenPreview(
+    @PreviewParameter(provider = CardListScreenPreviewParameterProvider::class) state: CardListState,
+) {
+    PaymentsTheme {
+        CardListScreen(
+            state = state,
+            navigateToNewCard = {},
+        )
     }
 }

--- a/app/src/main/java/nextstep/payments/ui/card_list/CardListScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/card_list/CardListScreen.kt
@@ -1,0 +1,13 @@
+package nextstep.payments.ui.card_list
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+fun CardListScreenRoot(
+    viewModel: CardListViewModel,
+    navigateToNewCard: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+
+}

--- a/app/src/main/java/nextstep/payments/ui/card_list/CardListScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/card_list/CardListScreen.kt
@@ -156,7 +156,6 @@ public class CardListScreenPreviewParameterProvider : PreviewParameterProvider<C
                         cardNumber = "1111111111111111",
                         expiredDate = "0000",
                         ownerName = "홍길동",
-                        password = "0000",
                     )
                 )
             ),
@@ -167,19 +166,16 @@ public class CardListScreenPreviewParameterProvider : PreviewParameterProvider<C
                             cardNumber = "4111-1111-1111-1111",
                             expiredDate = "12/27",
                             ownerName = "Kim Minsoo",
-                            password = "1234"
                         ),
                         CreditCard(
                             cardNumber = "5500-0000-0000-0004",
                             expiredDate = "07/26",
                             ownerName = "Lee Hana",
-                            password = "5678"
                         ),
                         CreditCard(
                             cardNumber = "3400-000000-00009",
                             expiredDate = "03/28",
                             ownerName = "Park Jiwon",
-                            password = "9876"
                         )
                     )
                 )

--- a/app/src/main/java/nextstep/payments/ui/card_list/CardListScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/card_list/CardListScreen.kt
@@ -2,7 +2,6 @@
 
 package nextstep.payments.ui.card_list
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -57,6 +56,7 @@ fun CardListScreen(
 ) {
     Scaffold(
         modifier = modifier,
+        containerColor = Color.White,
         topBar = {
             CenterAlignedTopAppBar(
                 title = {
@@ -121,8 +121,7 @@ private fun EmptyCardScreen(
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = modifier
-            .fillMaxSize()
-            .background(Color.White),
+            .fillMaxSize(),
     ) {
         Text(
             text = stringResource(R.string.card_list_add_new_card),
@@ -149,7 +148,6 @@ private fun ManyCardScreen(
         verticalArrangement = Arrangement.spacedBy(32.dp),
         modifier = modifier
             .fillMaxSize()
-            .background(Color.White)
     ) {
         items(
             items = state.creditCards,
@@ -173,8 +171,7 @@ fun OneCardScreen(
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier = modifier
-            .fillMaxSize()
-            .background(Color.White),
+            .fillMaxSize(),
     ) {
         PaymentCard(
             cardInfo = state.creditCard

--- a/app/src/main/java/nextstep/payments/ui/card_list/CardListScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/card_list/CardListScreen.kt
@@ -188,7 +188,7 @@ fun OneCardScreen(
     }
 }
 
-class CardListScreenPreviewParameterProvider : PreviewParameterProvider<CardListState> {
+private class CardListScreenPreviewParameterProvider : PreviewParameterProvider<CardListState> {
     override val values: Sequence<CardListState>
         get() = sequenceOf(
             CardListState(

--- a/app/src/main/java/nextstep/payments/ui/card_list/CardListScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/card_list/CardListScreen.kt
@@ -82,65 +82,109 @@ fun CardListScreen(
             )
         }
     ) { innerPadding ->
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            modifier = Modifier
-                .padding(innerPadding)
-                .fillMaxSize()
-                .background(Color.White),
-        ) {
-            /**
-             * 각 상황에 따른 UI를 미리 분리해 두는 것이 요구사항이 변경되었을 때 더 대응하기 쉽다고 생각해 when 절을 사용했습니다.
-             * Compound Component 패턴을 적용해야 할지 고민해봤는데, 적용해야 하는 이유와 어떻게 적용할지를 떠올리지 못했습니다.
-             * https://wisemuji.medium.com/jetpack-compose-ui-%EC%A1%B0%ED%95%A9-composition-%ED%95%98%EA%B8%B0-%EC%8B%AC%ED%99%94-33910e8f09df
-             */
-            when (val cards = state.cards) {
-                CreditCardUiState.Empty -> {
-                    Text(
-                        text = stringResource(R.string.card_list_add_new_card),
-                        fontWeight = FontWeight.Bold,
-                        fontSize = 18.sp,
-                        modifier = Modifier
-                            .padding(vertical = 32.dp)
-                    )
-                    PaymentCardAdd(
-                        modifier = Modifier.clickable {
-                            navigateToNewCard()
-                        }
-                    )
-                }
-
-                is CreditCardUiState.Many -> {
-                    LazyColumn(
-                        verticalArrangement = Arrangement.spacedBy(32.dp),
-                    ) {
-                        items(
-                            items = cards.creditCards,
-                            key = {
-                                it.cardNumber
-                            }
-                        ) {
-                            PaymentCard(
-                                cardInfo = it,
-                            )
-                        }
-                    }
-                }
-
-                is CreditCardUiState.One -> {
-                    PaymentCard(
-                        cardInfo = cards.creditCard
-                    )
-                    Spacer(modifier = Modifier.padding(bottom = 32.dp))
-                    PaymentCardAdd(
-                        modifier = Modifier.clickable {
-                            navigateToNewCard()
-                        }
-                    )
-                }
+        /**
+         * 각 상황에 따른 UI를 미리 분리해 두는 것이 요구사항이 변경되었을 때 더 대응하기 쉽다고 생각해 when 절을 사용했습니다.
+         * Compound Component 패턴을 적용해야 할지 고민해봤는데, 적용해야 하는 이유와 어떻게 적용할지를 떠올리지 못했습니다.
+         * https://wisemuji.medium.com/jetpack-compose-ui-%EC%A1%B0%ED%95%A9-composition-%ED%95%98%EA%B8%B0-%EC%8B%AC%ED%99%94-33910e8f09df
+         */
+        when (val cards = state.cards) {
+            CreditCardUiState.Empty -> {
+                EmptyCardScreen(
+                    modifier = Modifier.padding(innerPadding),
+                    navigateToNewCard = navigateToNewCard,
+                )
             }
 
+            is CreditCardUiState.Many -> {
+                ManyCardScreen(
+                    state = cards,
+                    modifier = Modifier.padding(innerPadding),
+                )
+            }
+
+            is CreditCardUiState.One -> {
+                OneCardScreen(
+                    state = cards,
+                    navigateToNewCard = navigateToNewCard,
+                    modifier = Modifier.padding(innerPadding),
+                )
+            }
         }
+    }
+}
+
+@Composable
+private fun EmptyCardScreen(
+    modifier: Modifier = Modifier,
+    navigateToNewCard: () -> Unit,
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier
+            .fillMaxSize()
+            .background(Color.White),
+    ) {
+        Text(
+            text = stringResource(R.string.card_list_add_new_card),
+            fontWeight = FontWeight.Bold,
+            fontSize = 18.sp,
+            modifier = Modifier
+                .padding(vertical = 32.dp)
+        )
+        PaymentCardAdd(
+            modifier = Modifier.clickable {
+                navigateToNewCard()
+            }
+        )
+    }
+}
+
+@Composable
+private fun ManyCardScreen(
+    state: CreditCardUiState.Many,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(32.dp),
+        modifier = modifier
+            .fillMaxSize()
+            .background(Color.White)
+    ) {
+        items(
+            items = state.creditCards,
+            key = {
+                it.cardNumber
+            }
+        ) {
+            PaymentCard(
+                cardInfo = it,
+            )
+        }
+    }
+}
+
+@Composable
+fun OneCardScreen(
+    state: CreditCardUiState.One,
+    navigateToNewCard: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier
+            .fillMaxSize()
+            .background(Color.White),
+    ) {
+        PaymentCard(
+            cardInfo = state.creditCard
+        )
+        Spacer(modifier = Modifier.padding(bottom = 32.dp))
+        PaymentCardAdd(
+            modifier = Modifier.clickable {
+                navigateToNewCard()
+            }
+        )
     }
 }
 

--- a/app/src/main/java/nextstep/payments/ui/card_list/CardListScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/card_list/CardListScreen.kt
@@ -20,6 +20,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -70,6 +72,9 @@ fun CardListScreen(
                             fontSize = 18.sp,
                             modifier = Modifier
                                 .padding(end = 16.dp)
+                                .semantics {
+                                    contentDescription = "TopAppBar 카드 추가 버튼"
+                                }
                                 .clickable {
                                     navigateToNewCard()
                                 },
@@ -128,6 +133,9 @@ private fun EmptyCardScreen(
             fontWeight = FontWeight.Bold,
             fontSize = 18.sp,
             modifier = Modifier
+                .semantics {
+                    contentDescription = "새로운 카드 등록 안내 문구"
+                }
                 .padding(vertical = 32.dp)
         )
         PaymentCardAdd(

--- a/app/src/main/java/nextstep/payments/ui/card_list/CardListScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/card_list/CardListScreen.kt
@@ -2,6 +2,7 @@
 
 package nextstep.payments.ui.card_list
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -14,9 +15,11 @@ import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
@@ -72,7 +75,10 @@ fun CardListScreen(
                                 },
                         )
                     }
-                }
+                },
+                colors = TopAppBarDefaults.topAppBarColors().copy(
+                    containerColor = Color.White
+                )
             )
         }
     ) { innerPadding ->
@@ -80,7 +86,8 @@ fun CardListScreen(
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier
                 .padding(innerPadding)
-                .fillMaxSize(),
+                .fillMaxSize()
+                .background(Color.White),
         ) {
             /**
              * 각 상황에 따른 UI를 미리 분리해 두는 것이 요구사항이 변경되었을 때 더 대응하기 쉽다고 생각해 when 절을 사용했습니다.

--- a/app/src/main/java/nextstep/payments/ui/card_list/CardListState.kt
+++ b/app/src/main/java/nextstep/payments/ui/card_list/CardListState.kt
@@ -1,0 +1,5 @@
+package nextstep.payments.ui.card_list
+
+data class CardListState(
+    val cards: CreditCardUiState = CreditCardUiState.Empty,
+)

--- a/app/src/main/java/nextstep/payments/ui/card_list/CardListViewModel.kt
+++ b/app/src/main/java/nextstep/payments/ui/card_list/CardListViewModel.kt
@@ -1,0 +1,10 @@
+package nextstep.payments.ui.card_list
+
+import androidx.lifecycle.ViewModel
+
+class CardListViewModel: ViewModel() {
+
+    fun fetchCards() {
+
+    }
+}

--- a/app/src/main/java/nextstep/payments/ui/card_list/CardListViewModel.kt
+++ b/app/src/main/java/nextstep/payments/ui/card_list/CardListViewModel.kt
@@ -1,10 +1,49 @@
 package nextstep.payments.ui.card_list
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import nextstep.payments.data.card.PaymentCardRepository
+import nextstep.payments.ui.mapper.toUi
 
-class CardListViewModel: ViewModel() {
+class CardListViewModel(
+    private val cardRepository: PaymentCardRepository,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(CardListState())
+    val state = _state.asStateFlow()
 
     fun fetchCards() {
+        _state.update {
+            val cards = cardRepository.cards.map { card ->
+                card.toUi()
+            }
+            it.copy(
+                cards = if (cards.isEmpty()) {
+                    CreditCardUiState.Empty
+                } else if (cards.size == 1) {
+                    CreditCardUiState.One(cards.first())
+                } else {
+                    CreditCardUiState.Many(cards)
+                }
+            )
+        }
+    }
 
+    companion object {
+        /**
+         * https://developer.android.com/topic/libraries/architecture/viewmodel/viewmodel-factories
+         */
+        val Factory: ViewModelProvider.Factory = viewModelFactory {
+            initializer {
+                val repository = PaymentCardRepository
+
+                CardListViewModel(repository)
+            }
+        }
     }
 }

--- a/app/src/main/java/nextstep/payments/ui/card_list/CreditCardUiState.kt
+++ b/app/src/main/java/nextstep/payments/ui/card_list/CreditCardUiState.kt
@@ -1,0 +1,9 @@
+package nextstep.payments.ui.card_list
+
+import nextstep.payments.ui.common.model.CreditCard
+
+sealed interface CreditCardUiState {
+    data object Empty : CreditCardUiState
+    data class One(val creditCard: CreditCard) : CreditCardUiState
+    data class Many(val creditCards: List<CreditCard>) : CreditCardUiState
+}

--- a/app/src/main/java/nextstep/payments/ui/common/CardExpiryTransformation.kt
+++ b/app/src/main/java/nextstep/payments/ui/common/CardExpiryTransformation.kt
@@ -1,0 +1,43 @@
+package nextstep.payments.ui.common
+
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.input.OffsetMapping
+import androidx.compose.ui.text.input.TransformedText
+import androidx.compose.ui.text.input.VisualTransformation
+
+/**
+ * 카드 만료일 입력("MMYY")을 "MM/YY" 포맷으로 변경해줍니다.
+ * filter에 입력하는 text가 카드 만료일 포맷에 맞는지 여부는 ViewModel에서 처리합니다.
+ */
+class CardExpiryTransformation : VisualTransformation {
+    override fun filter(text: AnnotatedString): TransformedText {
+        val raw = text.text.filter { it.isDigit() }
+        val out = if (raw.length <= 2) {
+            raw
+        } else {
+            raw.substring(0, 2) + "/" + raw.substring(2)
+        }
+
+        val offset = object : OffsetMapping {
+            override fun originalToTransformed(offset: Int): Int {
+                return if (raw.length <= 2 || offset <= 2) {
+                    offset
+                } else {
+                    offset + 1
+                }
+            }
+
+            override fun transformedToOriginal(offset: Int): Int {
+                return if (raw.length <= 2) {
+                    offset.coerceAtMost(raw.length)
+                } else if (offset <= 2) {
+                    offset
+                } else {
+                    (offset - 1).coerceAtMost(raw.length)
+                }
+            }
+        }
+
+        return TransformedText(AnnotatedString(out), offset)
+    }
+}

--- a/app/src/main/java/nextstep/payments/ui/common/CardNumberTransformation.kt
+++ b/app/src/main/java/nextstep/payments/ui/common/CardNumberTransformation.kt
@@ -1,0 +1,41 @@
+package nextstep.payments.ui.common
+
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.input.OffsetMapping
+import androidx.compose.ui.text.input.TransformedText
+import androidx.compose.ui.text.input.VisualTransformation
+
+class CardNumberTransformation(
+    private val groupSize: Int = 4,
+    private val sep: Char = '-',
+): VisualTransformation {
+
+    /**
+     * ViewModel에서 digit만 filtering 했으나, 여기서 한 번 더 필터링 했습니다.
+     */
+    override fun filter(text: AnnotatedString): TransformedText {
+        val raw = text.text.filter { it.isDigit() }
+        val out = buildString {
+            raw.forEachIndexed { i, c ->
+                if (i != 0 && i % groupSize == 0) {
+                    append(sep)
+                }
+                append(c)
+            }
+        }
+        // OffsetMapping : cursor 위치를 계산하는 클래스
+        val offset = object: OffsetMapping {
+            override fun originalToTransformed(offset: Int): Int {
+                val sepCount = offset / groupSize
+                return (offset + sepCount).coerceAtMost(out.length)
+            }
+
+            override fun transformedToOriginal(offset: Int): Int {
+                val sepCount = offset / (groupSize + 1)
+                return (offset - sepCount).coerceIn(0, raw.length)
+            }
+        }
+
+        return TransformedText(AnnotatedString(out), offset)
+    }
+}

--- a/app/src/main/java/nextstep/payments/ui/common/CardNumberTransformation.kt
+++ b/app/src/main/java/nextstep/payments/ui/common/CardNumberTransformation.kt
@@ -8,7 +8,7 @@ import androidx.compose.ui.text.input.VisualTransformation
 class CardNumberTransformation(
     private val groupSize: Int = 4,
     private val sep: Char = '-',
-): VisualTransformation {
+) : VisualTransformation {
 
     /**
      * ViewModel에서 digit만 filtering 했으나, 여기서 한 번 더 필터링 했습니다.
@@ -24,7 +24,7 @@ class CardNumberTransformation(
             }
         }
         // OffsetMapping : cursor 위치를 계산하는 클래스
-        val offset = object: OffsetMapping {
+        val offset = object : OffsetMapping {
             override fun originalToTransformed(offset: Int): Int {
                 val sepCount = offset / groupSize
                 return (offset + sepCount).coerceAtMost(out.length)

--- a/app/src/main/java/nextstep/payments/ui/common/model/Card.kt
+++ b/app/src/main/java/nextstep/payments/ui/common/model/Card.kt
@@ -1,0 +1,11 @@
+package nextstep.payments.ui.common.model
+
+/**
+ * 이 클래스가 common/model 하위에 있는데, 더 적절한 위치가 어디일지 궁금합니다.
+ */
+data class Card(
+    val cardNumber: String = "",
+    val expiredDate: String = "",
+    val ownerName: String = "",
+    val password: String = "",
+)

--- a/app/src/main/java/nextstep/payments/ui/common/model/CreditCard.kt
+++ b/app/src/main/java/nextstep/payments/ui/common/model/CreditCard.kt
@@ -7,5 +7,4 @@ data class CreditCard(
     val cardNumber: String = "",
     val expiredDate: String = "",
     val ownerName: String = "",
-    val password: String = "",
 )

--- a/app/src/main/java/nextstep/payments/ui/common/model/CreditCard.kt
+++ b/app/src/main/java/nextstep/payments/ui/common/model/CreditCard.kt
@@ -3,7 +3,7 @@ package nextstep.payments.ui.common.model
 /**
  * 이 클래스가 common/model 하위에 있는데, 더 적절한 위치가 어디일지 궁금합니다.
  */
-data class Card(
+data class CreditCard(
     val cardNumber: String = "",
     val expiredDate: String = "",
     val ownerName: String = "",

--- a/app/src/main/java/nextstep/payments/ui/common/model/CreditCard.kt
+++ b/app/src/main/java/nextstep/payments/ui/common/model/CreditCard.kt
@@ -1,5 +1,7 @@
 package nextstep.payments.ui.common.model
 
+import kotlin.text.filter
+
 /**
  * 이 클래스가 common/model 하위에 있는데, 더 적절한 위치가 어디일지 궁금합니다.
  */
@@ -7,4 +9,21 @@ data class CreditCard(
     val cardNumber: String = "",
     val expiredDate: String = "",
     val ownerName: String = "",
-)
+) {
+    fun formatExpiredDate(): String {
+        val groups = expiredDate.filter { it.isDigit() }.chunked(2)
+        return groups.joinToString(" / ")
+    }
+
+    fun maskedCardNumber(unmaskedGroups: Int): String {
+        val groups = cardNumber.filter { it.isDigit() }.chunked(4)
+
+        return groups.mapIndexed { index, group ->
+            if (index < unmaskedGroups) {
+                group
+            } else {
+                "*".repeat(group.length)
+            }
+        }.joinToString(" - ")
+    }
+}

--- a/app/src/main/java/nextstep/payments/ui/components/PaymentCard.kt
+++ b/app/src/main/java/nextstep/payments/ui/components/PaymentCard.kt
@@ -56,7 +56,7 @@ fun PaymentCard(
         )
 
         Text(
-            text = cardInfo.cardNumber.maskCardNumber(),
+            text = cardInfo.maskedCardNumber(2),
             modifier = Modifier
                 .constrainAs(cardNumber) {
                     start.linkTo(chip.start)
@@ -92,7 +92,7 @@ fun PaymentCard(
         )
 
         Text(
-            text = cardInfo.expiredDate.expiredFormat(),
+            text = cardInfo.formatExpiredDate(),
             modifier = Modifier
                 .constrainAs(expiredDate) {
                     start.linkTo(ownerName.end)
@@ -110,23 +110,6 @@ fun PaymentCard(
             textAlign = TextAlign.End,
         )
     }
-}
-
-private fun String.maskCardNumber(): String {
-    val groups = filter { it.isDigit() }.chunked(4)
-
-    return groups.mapIndexed { index, group ->
-        if (index < 2) {
-            group
-        } else {
-            "*".repeat(group.length)
-        }
-    }.joinToString(" - ")
-}
-
-private fun String.expiredFormat(): String {
-    val groups = filter { it.isDigit() }.chunked(2)
-    return groups.joinToString(" / ")
 }
 
 @Preview

--- a/app/src/main/java/nextstep/payments/ui/components/PaymentCard.kt
+++ b/app/src/main/java/nextstep/payments/ui/components/PaymentCard.kt
@@ -45,8 +45,8 @@ fun PaymentCard(
         Box(
             modifier = Modifier
                 .constrainAs(chip) {
-                    start.linkTo(parent.start, margin = 14.dp)
-                    centerVerticallyTo(parent, 0.45f)
+                    centerHorizontallyTo(parent, 0.1197f)
+                    centerVerticallyTo(parent, 0.3562f)
                 }
                 .size(width = 40.dp, height = 26.dp)
                 .background(
@@ -106,7 +106,7 @@ fun PaymentCard(
             color = Color.White,
             fontWeight = FontWeight.W500,
             maxLines = 1,
-            autoSize = TextAutoSize.StepBased(),
+            autoSize = TextAutoSize.StepBased(maxFontSize = 12.sp),
             textAlign = TextAlign.End,
         )
     }

--- a/app/src/main/java/nextstep/payments/ui/components/PaymentCard.kt
+++ b/app/src/main/java/nextstep/payments/ui/components/PaymentCard.kt
@@ -138,7 +138,6 @@ private fun PaymentCardPreview() {
                 cardNumber = "1111111111111111",
                 expiredDate = "1111",
                 ownerName = "Elon Reeve Musk Long Long Long",
-                password = "1234",
             )
         )
     }

--- a/app/src/main/java/nextstep/payments/ui/components/PaymentCard.kt
+++ b/app/src/main/java/nextstep/payments/ui/components/PaymentCard.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.constraintlayout.compose.ConstraintLayout
+import androidx.constraintlayout.compose.Dimension
 import nextstep.payments.ui.common.model.CreditCard
 import nextstep.payments.ui.theme.PaymentsTheme
 
@@ -63,9 +64,12 @@ fun PaymentCard(
                     start.linkTo(parent.start, 14.dp)
                     end.linkTo(parent.end, 14.dp)
                     top.linkTo(chip.bottom, margin = 8.dp)
+                    width = Dimension.fillToConstraints // Composable width가 제약에 맞게 늘어나도록 설정
                 },
             color = Color.White,
             fontWeight = FontWeight.W500,
+            maxLines = 1,
+            autoSize = TextAutoSize.StepBased() // Material3 version 1.4에 추가된 autoSize 사용. ref: https://stackoverflow.com/a/79704166/11722881
         )
     }
 }
@@ -79,7 +83,7 @@ private fun String.maskCardNumber(): String {
         } else {
             "*".repeat(group.length)
         }
-    }.joinToString("-")
+    }.joinToString(" - ")
 }
 
 @Preview

--- a/app/src/main/java/nextstep/payments/ui/components/PaymentCard.kt
+++ b/app/src/main/java/nextstep/payments/ui/components/PaymentCard.kt
@@ -1,10 +1,7 @@
 package nextstep.payments.ui.components
 
-import android.R.attr.end
-import android.R.attr.top
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.TextAutoSize
@@ -14,6 +11,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -61,9 +59,10 @@ fun PaymentCard(
             text = cardInfo.cardNumber.maskCardNumber(),
             modifier = Modifier
                 .constrainAs(cardNumber) {
-                    start.linkTo(parent.start, 14.dp)
+                    start.linkTo(chip.start)
                     end.linkTo(parent.end, 14.dp)
                     top.linkTo(chip.bottom, margin = 8.dp)
+
                     width = Dimension.fillToConstraints // Composable width가 제약에 맞게 늘어나도록 설정
                 },
             color = Color.White,
@@ -71,11 +70,50 @@ fun PaymentCard(
             maxLines = 1,
             autoSize = TextAutoSize.StepBased() // Material3 version 1.4에 추가된 autoSize 사용. ref: https://stackoverflow.com/a/79704166/11722881
         )
+        Text(
+            text = cardInfo.ownerName,
+            modifier = Modifier
+                .constrainAs(ownerName) {
+                    start.linkTo(chip.start)
+                    end.linkTo(expiredDate.start)
+                    top.linkTo(cardNumber.bottom)
+                    bottom.linkTo(
+                        parent.bottom,
+                        8.dp
+                    ) // 이렇게 설정할 경우, CardNumber Text Composable과 일부가 겹치지만, 대안이 떠오르지 않네요.
+
+                    width = Dimension.fillToConstraints
+                },
+            color = Color.White,
+            fontWeight = FontWeight.W500,
+            autoSize = TextAutoSize.StepBased(maxFontSize = 12.sp),
+            maxLines = 1,
+            textAlign = TextAlign.Start,
+        )
+
+        Text(
+            text = cardInfo.expiredDate.expiredFormat(),
+            modifier = Modifier
+                .constrainAs(expiredDate) {
+                    start.linkTo(ownerName.end)
+                    end.linkTo(parent.end, margin = 14.dp)
+                    top.linkTo(ownerName.top)
+                    bottom.linkTo(parent.bottom, 8.dp)
+
+                    width = Dimension.wrapContent
+                    height = Dimension.fillToConstraints
+                },
+            color = Color.White,
+            fontWeight = FontWeight.W500,
+            maxLines = 1,
+            autoSize = TextAutoSize.StepBased(),
+            textAlign = TextAlign.End,
+        )
     }
 }
 
 private fun String.maskCardNumber(): String {
-    val groups = chunked(4)
+    val groups = filter { it.isDigit() }.chunked(4)
 
     return groups.mapIndexed { index, group ->
         if (index < 2) {
@@ -86,6 +124,11 @@ private fun String.maskCardNumber(): String {
     }.joinToString(" - ")
 }
 
+private fun String.expiredFormat(): String {
+    val groups = filter { it.isDigit() }.chunked(2)
+    return groups.joinToString(" / ")
+}
+
 @Preview
 @Composable
 private fun PaymentCardPreview() {
@@ -94,7 +137,7 @@ private fun PaymentCardPreview() {
             cardInfo = CreditCard(
                 cardNumber = "1111111111111111",
                 expiredDate = "1111",
-                ownerName = "홍길동",
+                ownerName = "Elon Reeve Musk Long Long Long",
                 password = "1234",
             )
         )

--- a/app/src/main/java/nextstep/payments/ui/components/PaymentCard.kt
+++ b/app/src/main/java/nextstep/payments/ui/components/PaymentCard.kt
@@ -1,27 +1,38 @@
 package nextstep.payments.ui.components
 
+import android.R.attr.end
+import android.R.attr.top
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.TextAutoSize
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.constraintlayout.compose.ConstraintLayout
 import nextstep.payments.ui.common.model.CreditCard
 import nextstep.payments.ui.theme.PaymentsTheme
 
+/**
+ * 카드 chip 하단 8dp에 카드 번호를 추가해야 한다는 요구 조건을 보고 ConstraintLayout을 떠올렸습니다.
+ * ConstraintLayout 없이 Box, Row, Column 만을 이용해서 구현하는 방법을 AI에게 물어봤으나, 하드코딩된 padding 방법만 알려줬습니다.
+ * Custom Layout으로 구현해보려고 관련 강의를 봤는데, ConstraintLayout보다 더 복잡해지는 방법이란 생각이 들었습니다.
+ * 그래서 ConstraintLayout을 이용해 구현했습니다.
+ */
 @Composable
 fun PaymentCard(
     modifier: Modifier = Modifier,
     cardInfo: CreditCard = CreditCard(),
 ) {
-    Box(
-        contentAlignment = Alignment.CenterStart,
+    ConstraintLayout(
         modifier = modifier
             .shadow(8.dp)
             .size(width = 208.dp, height = 124.dp)
@@ -30,22 +41,58 @@ fun PaymentCard(
                 shape = RoundedCornerShape(5.dp),
             )
     ) {
+        val (chip, cardNumber, expiredDate, ownerName) = createRefs()
+
         Box(
             modifier = Modifier
-                .padding(start = 14.dp, bottom = 10.dp)
+                .constrainAs(chip) {
+                    start.linkTo(parent.start, margin = 14.dp)
+                    centerVerticallyTo(parent, 0.45f)
+                }
                 .size(width = 40.dp, height = 26.dp)
                 .background(
                     color = Color(0xFFCBBA64),
                     shape = RoundedCornerShape(4.dp),
                 )
         )
+
+        Text(
+            text = cardInfo.cardNumber.maskCardNumber(),
+            modifier = Modifier
+                .constrainAs(cardNumber) {
+                    start.linkTo(parent.start, 14.dp)
+                    end.linkTo(parent.end, 14.dp)
+                    top.linkTo(chip.bottom, margin = 8.dp)
+                },
+            color = Color.White,
+            fontWeight = FontWeight.W500,
+        )
     }
+}
+
+private fun String.maskCardNumber(): String {
+    val groups = chunked(4)
+
+    return groups.mapIndexed { index, group ->
+        if (index < 2) {
+            group
+        } else {
+            "*".repeat(group.length)
+        }
+    }.joinToString("-")
 }
 
 @Preview
 @Composable
 private fun PaymentCardPreview() {
     PaymentsTheme {
-        PaymentCard()
+        PaymentCard(
+            cardInfo = CreditCard(
+                cardNumber = "1111111111111111",
+                expiredDate = "1111",
+                ownerName = "홍길동",
+                password = "1234",
+            )
+        )
     }
 }

--- a/app/src/main/java/nextstep/payments/ui/components/PaymentCardAdd.kt
+++ b/app/src/main/java/nextstep/payments/ui/components/PaymentCardAdd.kt
@@ -2,50 +2,44 @@ package nextstep.payments.ui.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import nextstep.payments.ui.common.model.CreditCard
+import androidx.compose.ui.unit.sp
 import nextstep.payments.ui.theme.PaymentsTheme
 
 @Composable
-fun PaymentCard(
-    modifier: Modifier = Modifier,
-    cardInfo: CreditCard = CreditCard(),
-) {
+fun PaymentCardAdd(modifier: Modifier = Modifier) {
     Box(
-        contentAlignment = Alignment.CenterStart,
+        contentAlignment = Alignment.Center,
         modifier = modifier
-            .shadow(8.dp)
             .size(width = 208.dp, height = 124.dp)
             .background(
-                color = Color(0xFF333333),
+                color = Color(0xFFE5E5E5),
                 shape = RoundedCornerShape(5.dp),
             )
     ) {
-        Box(
-            modifier = Modifier
-                .padding(start = 14.dp, bottom = 10.dp)
-                .size(width = 40.dp, height = 26.dp)
-                .background(
-                    color = Color(0xFFCBBA64),
-                    shape = RoundedCornerShape(4.dp),
-                )
+        Text(
+            text = "+",
+            fontSize = 34.sp,
+            fontWeight = FontWeight.W400,
+            textAlign = TextAlign.Center,
         )
     }
 }
 
 @Preview
 @Composable
-private fun PaymentCardPreview() {
+private fun PaymentCardAddPreview() {
     PaymentsTheme {
-        PaymentCard()
+        PaymentCardAdd()
     }
 }

--- a/app/src/main/java/nextstep/payments/ui/mapper/CardMapper.kt
+++ b/app/src/main/java/nextstep/payments/ui/mapper/CardMapper.kt
@@ -8,5 +8,4 @@ fun CardEntity.toUi(): CreditCard =
         cardNumber = cardNumber,
         expiredDate = expiredDate,
         ownerName = ownerName,
-        password = password
     )

--- a/app/src/main/java/nextstep/payments/ui/mapper/CardMapper.kt
+++ b/app/src/main/java/nextstep/payments/ui/mapper/CardMapper.kt
@@ -1,0 +1,12 @@
+package nextstep.payments.ui.mapper
+
+import nextstep.payments.data.card.CardEntity
+import nextstep.payments.ui.common.model.Card
+
+fun CardEntity.toUi(): Card =
+    Card(
+        cardNumber = cardNumber,
+        expiredDate = expiredDate,
+        ownerName = ownerName,
+        password = password
+    )

--- a/app/src/main/java/nextstep/payments/ui/mapper/CardMapper.kt
+++ b/app/src/main/java/nextstep/payments/ui/mapper/CardMapper.kt
@@ -1,10 +1,10 @@
 package nextstep.payments.ui.mapper
 
 import nextstep.payments.data.card.CardEntity
-import nextstep.payments.ui.common.model.Card
+import nextstep.payments.ui.common.model.CreditCard
 
-fun CardEntity.toUi(): Card =
-    Card(
+fun CardEntity.toUi(): CreditCard =
+    CreditCard(
         cardNumber = cardNumber,
         expiredDate = expiredDate,
         ownerName = ownerName,

--- a/app/src/main/java/nextstep/payments/ui/new_card/CardInputValidator.kt
+++ b/app/src/main/java/nextstep/payments/ui/new_card/CardInputValidator.kt
@@ -1,0 +1,25 @@
+package nextstep.payments.ui.new_card
+
+
+object CardInputValidator {
+    const val CARD_NUMBER_MAX_LENGTH = 19
+    const val CARD_EXPIRED_DATE_MAX_LENGTH = 5
+    const val CARD_OWNER_NAME_MAX_LENGTH = 30
+    const val CARD_PASSWORD_MAX_LENGTH = 4
+
+    fun isCardNumberValid(cardNumber: String): Boolean {
+        return cardNumber.length == CARD_NUMBER_MAX_LENGTH && cardNumber.all { it.isDigit() || it == '-' }
+    }
+
+    fun isExpiredDateValid(expiredDate: String): Boolean {
+        return expiredDate.length == CARD_EXPIRED_DATE_MAX_LENGTH && expiredDate.all { it.isDigit() || it == '/' }
+    }
+
+    fun isCardOwnerNameValid(cardOwnerName: String): Boolean {
+        return cardOwnerName.length <= CARD_OWNER_NAME_MAX_LENGTH
+    }
+
+    fun isPasswordValid(password: String): Boolean {
+        return password.length == CARD_PASSWORD_MAX_LENGTH && password.all { it.isDigit() }
+    }
+}

--- a/app/src/main/java/nextstep/payments/ui/new_card/CardInputValidator.kt
+++ b/app/src/main/java/nextstep/payments/ui/new_card/CardInputValidator.kt
@@ -2,13 +2,13 @@ package nextstep.payments.ui.new_card
 
 
 object CardInputValidator {
-    const val CARD_NUMBER_MAX_LENGTH = 19
+    const val CARD_TEXT_NUMBER_MAX_LENGTH = 19
     const val CARD_EXPIRED_DATE_MAX_LENGTH = 5
     const val CARD_OWNER_NAME_MAX_LENGTH = 30
     const val CARD_PASSWORD_MAX_LENGTH = 4
 
     fun isCardNumberValid(cardNumber: String): Boolean {
-        return cardNumber.length == CARD_NUMBER_MAX_LENGTH && cardNumber.all { it.isDigit() || it == '-' }
+        return cardNumber.length == CARD_TEXT_NUMBER_MAX_LENGTH && cardNumber.all { it.isDigit() || it == '-' }
     }
 
     fun isExpiredDateValid(expiredDate: String): Boolean {

--- a/app/src/main/java/nextstep/payments/ui/new_card/CardInputValidator.kt
+++ b/app/src/main/java/nextstep/payments/ui/new_card/CardInputValidator.kt
@@ -3,7 +3,7 @@ package nextstep.payments.ui.new_card
 
 object CardInputValidator {
     const val CARD_TEXT_NUMBER_MAX_LENGTH = 19
-    const val CARD_EXPIRED_DATE_MAX_LENGTH = 5
+    const val CARD_EXPIRED_DATE_TEXT_MAX_LENGTH = 5
     const val CARD_OWNER_NAME_MAX_LENGTH = 30
     const val CARD_PASSWORD_MAX_LENGTH = 4
 
@@ -12,7 +12,7 @@ object CardInputValidator {
     }
 
     fun isExpiredDateValid(expiredDate: String): Boolean {
-        return expiredDate.length == CARD_EXPIRED_DATE_MAX_LENGTH && expiredDate.all { it.isDigit() || it == '/' }
+        return expiredDate.length == CARD_EXPIRED_DATE_TEXT_MAX_LENGTH && expiredDate.all { it.isDigit() || it == '/' }
     }
 
     fun isCardOwnerNameValid(cardOwnerName: String): Boolean {

--- a/app/src/main/java/nextstep/payments/ui/new_card/CardInputValidator.kt
+++ b/app/src/main/java/nextstep/payments/ui/new_card/CardInputValidator.kt
@@ -2,17 +2,17 @@ package nextstep.payments.ui.new_card
 
 
 object CardInputValidator {
-    const val CARD_TEXT_NUMBER_MAX_LENGTH = 19
-    const val CARD_EXPIRED_DATE_TEXT_MAX_LENGTH = 5
+    const val CARD_NUMBER_MAX_LENGTH = 16
+    const val CARD_EXPIRED_DATE_MAX_LENGTH = 4
     const val CARD_OWNER_NAME_MAX_LENGTH = 30
     const val CARD_PASSWORD_MAX_LENGTH = 4
 
     fun isCardNumberValid(cardNumber: String): Boolean {
-        return cardNumber.length == CARD_TEXT_NUMBER_MAX_LENGTH && cardNumber.all { it.isDigit() || it == '-' }
+        return cardNumber.length == CARD_NUMBER_MAX_LENGTH && cardNumber.all { it.isDigit() }
     }
 
     fun isExpiredDateValid(expiredDate: String): Boolean {
-        return expiredDate.length == CARD_EXPIRED_DATE_TEXT_MAX_LENGTH && expiredDate.all { it.isDigit() || it == '/' }
+        return expiredDate.length == CARD_EXPIRED_DATE_MAX_LENGTH && expiredDate.all { it.isDigit() }
     }
 
     fun isCardOwnerNameValid(cardOwnerName: String): Boolean {

--- a/app/src/main/java/nextstep/payments/ui/new_card/NewCardAction.kt
+++ b/app/src/main/java/nextstep/payments/ui/new_card/NewCardAction.kt
@@ -6,5 +6,5 @@ sealed interface NewCardAction {
     data class OnOwnerNameChange(val ownerName: String) : NewCardAction
     data class OnPasswordChange(val password: String) : NewCardAction
     data object OnAddCardClick : NewCardAction
-    data object OnBackClick: NewCardAction
+    data object OnBackClick : NewCardAction
 }

--- a/app/src/main/java/nextstep/payments/ui/new_card/NewCardAction.kt
+++ b/app/src/main/java/nextstep/payments/ui/new_card/NewCardAction.kt
@@ -1,10 +1,8 @@
 package nextstep.payments.ui.new_card
 
-import androidx.compose.ui.text.input.TextFieldValue
-
 sealed interface NewCardAction {
-    data class OnCartNumberChange(val cardNumber: TextFieldValue) : NewCardAction
-    data class OnExpiredDateChange(val expiredDate: TextFieldValue) : NewCardAction
+    data class OnCartNumberChange(val cardNumber: String) : NewCardAction
+    data class OnExpiredDateChange(val expiredDate: String) : NewCardAction
     data class OnOwnerNameChange(val ownerName: String) : NewCardAction
     data class OnPasswordChange(val password: String) : NewCardAction
     data object OnAddCardClick : NewCardAction

--- a/app/src/main/java/nextstep/payments/ui/new_card/NewCardAction.kt
+++ b/app/src/main/java/nextstep/payments/ui/new_card/NewCardAction.kt
@@ -7,4 +7,6 @@ sealed interface NewCardAction {
     data class OnExpiredDateChange(val expiredDate: TextFieldValue) : NewCardAction
     data class OnOwnerNameChange(val ownerName: String) : NewCardAction
     data class OnPasswordChange(val password: String) : NewCardAction
+    data object OnAddCardClick : NewCardAction
+    data object OnBackClick: NewCardAction
 }

--- a/app/src/main/java/nextstep/payments/ui/new_card/NewCardActivity.kt
+++ b/app/src/main/java/nextstep/payments/ui/new_card/NewCardActivity.kt
@@ -1,0 +1,23 @@
+package nextstep.payments.ui.new_card
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import nextstep.payments.ui.theme.PaymentsTheme
+
+class NewCardActivity: ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            PaymentsTheme {
+                NewCardScreenRoot(
+                    navigateToCardList = {
+                        setResult(RESULT_OK)
+                        finish()
+                    }
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/nextstep/payments/ui/new_card/NewCardActivity.kt
+++ b/app/src/main/java/nextstep/payments/ui/new_card/NewCardActivity.kt
@@ -5,7 +5,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import nextstep.payments.ui.theme.PaymentsTheme
 
-class NewCardActivity: ComponentActivity() {
+class NewCardActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/nextstep/payments/ui/new_card/NewCardEvent.kt
+++ b/app/src/main/java/nextstep/payments/ui/new_card/NewCardEvent.kt
@@ -1,0 +1,6 @@
+package nextstep.payments.ui.new_card
+
+sealed interface NewCardEvent {
+
+    data object CardAdded: NewCardEvent
+}

--- a/app/src/main/java/nextstep/payments/ui/new_card/NewCardEvent.kt
+++ b/app/src/main/java/nextstep/payments/ui/new_card/NewCardEvent.kt
@@ -2,6 +2,7 @@ package nextstep.payments.ui.new_card
 
 sealed interface NewCardEvent {
 
-    data object CardAdded: NewCardEvent
+    data object CardAddSuccess: NewCardEvent
+    data object CardAddFail: NewCardEvent
     data object NavigateBack: NewCardEvent
 }

--- a/app/src/main/java/nextstep/payments/ui/new_card/NewCardEvent.kt
+++ b/app/src/main/java/nextstep/payments/ui/new_card/NewCardEvent.kt
@@ -2,7 +2,7 @@ package nextstep.payments.ui.new_card
 
 sealed interface NewCardEvent {
 
-    data object CardAddSuccess: NewCardEvent
-    data object CardAddFail: NewCardEvent
-    data object NavigateBack: NewCardEvent
+    data object CardAddSuccess : NewCardEvent
+    data object CardAddFail : NewCardEvent
+    data object NavigateBack : NewCardEvent
 }

--- a/app/src/main/java/nextstep/payments/ui/new_card/NewCardEvent.kt
+++ b/app/src/main/java/nextstep/payments/ui/new_card/NewCardEvent.kt
@@ -3,4 +3,5 @@ package nextstep.payments.ui.new_card
 sealed interface NewCardEvent {
 
     data object CardAdded: NewCardEvent
+    data object NavigateBack: NewCardEvent
 }

--- a/app/src/main/java/nextstep/payments/ui/new_card/NewCardScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/new_card/NewCardScreen.kt
@@ -26,6 +26,8 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import nextstep.payments.R
 import nextstep.payments.common.ObserveAsEvents
+import nextstep.payments.ui.common.CardExpiryTransformation
+import nextstep.payments.ui.common.CardNumberTransformation
 import nextstep.payments.ui.components.PaymentCard
 import nextstep.payments.ui.theme.PaymentsTheme
 
@@ -50,8 +52,8 @@ fun NewCardScreenRoot(
 
     val isAddEnabled by remember(state) {
         derivedStateOf {
-            CardInputValidator.isCardNumberValid(state.cardNumber.text) &&
-                    CardInputValidator.isExpiredDateValid(state.expiredDate.text) &&
+            CardInputValidator.isCardNumberValid(state.cardNumber) &&
+                    CardInputValidator.isExpiredDateValid(state.expiredDate) &&
                     CardInputValidator.isCardOwnerNameValid(state.ownerName) &&
                     CardInputValidator.isPasswordValid(state.password)
         }
@@ -107,6 +109,7 @@ fun NewCardScreen(
                 keyboardOptions = KeyboardOptions(
                     keyboardType = KeyboardType.Number,
                 ),
+                visualTransformation = CardNumberTransformation(),
                 label = { Text(stringResource(R.string.card_number_label)) },
                 placeholder = { Text(stringResource(R.string.card_number_placeholder)) },
                 modifier = Modifier.fillMaxWidth(),
@@ -120,6 +123,7 @@ fun NewCardScreen(
                 keyboardOptions = KeyboardOptions(
                     keyboardType = KeyboardType.Number,
                 ),
+                visualTransformation = CardExpiryTransformation(),
                 label = { Text(stringResource(R.string.expired_date_label)) },
                 placeholder = { Text(stringResource(R.string.expired_date_placeholder)) },
                 modifier = Modifier.fillMaxWidth(),
@@ -158,8 +162,8 @@ private fun NewCardScreenPreview() {
     PaymentsTheme {
         NewCardScreen(
             state = NewCardState(
-                cardNumber = TextFieldValue("1111-1111-1111-1111"),
-                expiredDate = TextFieldValue("00 / 00"),
+                cardNumber = "1111111111111111",
+                expiredDate = "0000",
                 ownerName = "홍길동",
                 password = "0000",
             ),

--- a/app/src/main/java/nextstep/payments/ui/new_card/NewCardScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/new_card/NewCardScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
@@ -125,6 +126,7 @@ fun NewCardScreen(
                 },
                 keyboardOptions = KeyboardOptions(
                     keyboardType = KeyboardType.Number,
+                    imeAction = ImeAction.Next,
                 ),
                 visualTransformation = CardNumberTransformation(),
                 label = { Text(stringResource(R.string.card_number_label)) },
@@ -139,6 +141,7 @@ fun NewCardScreen(
                 },
                 keyboardOptions = KeyboardOptions(
                     keyboardType = KeyboardType.Number,
+                    imeAction = ImeAction.Next,
                 ),
                 visualTransformation = CardExpiryTransformation(),
                 label = { Text(stringResource(R.string.expired_date_label)) },
@@ -151,6 +154,9 @@ fun NewCardScreen(
                 onValueChange = {
                     onAction(NewCardAction.OnOwnerNameChange(it))
                 },
+                keyboardOptions = KeyboardOptions(
+                    imeAction = ImeAction.Next,
+                ),
                 label = { Text(stringResource(R.string.owner_name_label)) },
                 placeholder = { Text(stringResource(R.string.owner_name_placeholder)) },
                 modifier = Modifier.fillMaxWidth(),
@@ -163,6 +169,7 @@ fun NewCardScreen(
                 },
                 keyboardOptions = KeyboardOptions(
                     keyboardType = KeyboardType.Number,
+                    imeAction = ImeAction.Done,
                 ),
                 label = { Text(stringResource(R.string.password_label)) },
                 placeholder = { Text(stringResource(R.string.password_placeholder)) },

--- a/app/src/main/java/nextstep/payments/ui/new_card/NewCardScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/new_card/NewCardScreen.kt
@@ -69,10 +69,7 @@ fun NewCardScreenRoot(
 
     val isAddEnabled by remember {
         derivedStateOf {
-            CardInputValidator.isCardNumberValid(state.cardNumber) &&
-                    CardInputValidator.isExpiredDateValid(state.expiredDate) &&
-                    CardInputValidator.isCardOwnerNameValid(state.ownerName) &&
-                    CardInputValidator.isPasswordValid(state.password)
+            state.isValid(CardInputValidator)
         }
     }
 

--- a/app/src/main/java/nextstep/payments/ui/new_card/NewCardScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/new_card/NewCardScreen.kt
@@ -67,7 +67,7 @@ fun NewCardScreenRoot(
         }
     }
 
-    val isAddEnabled by remember(state) {
+    val isAddEnabled by remember {
         derivedStateOf {
             CardInputValidator.isCardNumberValid(state.cardNumber) &&
                     CardInputValidator.isExpiredDateValid(state.expiredDate) &&

--- a/app/src/main/java/nextstep/payments/ui/new_card/NewCardScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/new_card/NewCardScreen.kt
@@ -11,7 +11,9 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -40,11 +42,24 @@ fun NewCardScreenRoot(
             NewCardEvent.CardAdded -> {
                 navigateToCardList()
             }
+            NewCardEvent.NavigateBack -> {
+                navigateToCardList()
+            }
+        }
+    }
+
+    val isAddEnabled by remember(state) {
+        derivedStateOf {
+            CardInputValidator.isCardNumberValid(state.cardNumber.text) &&
+                    CardInputValidator.isExpiredDateValid(state.expiredDate.text) &&
+                    CardInputValidator.isCardOwnerNameValid(state.ownerName) &&
+                    CardInputValidator.isPasswordValid(state.password)
         }
     }
 
     NewCardScreen(
         state = state,
+        isAddEnabled = isAddEnabled,
         onAction = viewModel::onAction,
         modifier = modifier,
     )
@@ -53,11 +68,22 @@ fun NewCardScreenRoot(
 @Composable
 fun NewCardScreen(
     state: NewCardState,
+    isAddEnabled: Boolean,
     onAction: (NewCardAction) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Scaffold(
-        topBar = { NewCardTopBar(onBackClick = { TODO() }, onSaveClick = { TODO() }) },
+        topBar = {
+            NewCardTopBar(
+                onBackClick = {
+                    onAction(NewCardAction.OnBackClick)
+                },
+                onSaveClick = {
+                    onAction(NewCardAction.OnAddCardClick)
+                },
+                isAddEnabled = isAddEnabled,
+            )
+        },
         modifier = modifier
     ) { innerPadding ->
         Column(
@@ -137,6 +163,7 @@ private fun NewCardScreenPreview() {
                 ownerName = "홍길동",
                 password = "0000",
             ),
+            isAddEnabled = true,
             onAction = { },
         )
     }

--- a/app/src/main/java/nextstep/payments/ui/new_card/NewCardScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/new_card/NewCardScreen.kt
@@ -1,7 +1,6 @@
 package nextstep.payments.ui.new_card
 
 import android.widget.Toast
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -104,6 +103,7 @@ fun NewCardScreen(
                 isAddEnabled = isAddEnabled,
             )
         },
+        containerColor = Color.White,
         modifier = modifier
     ) { innerPadding ->
         Column(
@@ -112,7 +112,6 @@ fun NewCardScreen(
             modifier = Modifier
                 .padding(innerPadding)
                 .fillMaxSize()
-                .background(Color.White)
                 .padding(horizontal = 24.dp)
         ) {
             Spacer(modifier = Modifier.height(14.dp))

--- a/app/src/main/java/nextstep/payments/ui/new_card/NewCardScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/new_card/NewCardScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -55,9 +54,11 @@ fun NewCardScreenRoot(
             NewCardEvent.CardAddSuccess -> {
                 navigateToCardList()
             }
+
             NewCardEvent.CardAddFail -> {
                 Toast.makeText(context, cardAddFailMessage, Toast.LENGTH_SHORT).show()
             }
+
             NewCardEvent.NavigateBack -> {
                 navigateToCardList()
             }

--- a/app/src/main/java/nextstep/payments/ui/new_card/NewCardScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/new_card/NewCardScreen.kt
@@ -48,7 +48,9 @@ fun NewCardScreenRoot(
     // 그런데 이렇게 작성하면 사용되는 장소와 사용하는 장소가 분리되어 적절하지 않다고 생각됩니다.
     // 어떻게 수정하는 것이 좋을지 궁금합니다.
     val context = LocalContext.current
-    val cardAddFailMessage = stringResource(R.string.card_list_add_new_card_fail)
+    val cardAddFailMessage = remember {
+        context.getString(R.string.card_list_add_new_card_fail)
+    }
 
     ObserveAsEvents(viewModel.events) { event ->
         when (event) {

--- a/app/src/main/java/nextstep/payments/ui/new_card/NewCardScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/new_card/NewCardScreen.kt
@@ -23,15 +23,25 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import nextstep.payments.R
+import nextstep.payments.common.ObserveAsEvents
 import nextstep.payments.ui.components.PaymentCard
 import nextstep.payments.ui.theme.PaymentsTheme
 
 @Composable
-fun NewCardScreen(
+fun NewCardScreenRoot(
+    navigateToCardList: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: NewCardViewModel = viewModel(),
 ) {
     val state by viewModel.cardState.collectAsStateWithLifecycle()
+
+    ObserveAsEvents(viewModel.events) { event ->
+        when (event) {
+            NewCardEvent.CardAdded -> {
+                navigateToCardList()
+            }
+        }
+    }
 
     NewCardScreen(
         state = state,
@@ -41,7 +51,7 @@ fun NewCardScreen(
 }
 
 @Composable
-private fun NewCardScreen(
+fun NewCardScreen(
     state: NewCardState,
     onAction: (NewCardAction) -> Unit,
     modifier: Modifier = Modifier,

--- a/app/src/main/java/nextstep/payments/ui/new_card/NewCardScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/new_card/NewCardScreen.kt
@@ -1,8 +1,10 @@
 package nextstep.payments.ui.new_card
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -16,6 +18,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
@@ -93,6 +96,8 @@ fun NewCardScreen(
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier
                 .padding(innerPadding)
+                .fillMaxSize()
+                .background(Color.White)
                 .padding(horizontal = 24.dp)
         ) {
             Spacer(modifier = Modifier.height(14.dp))

--- a/app/src/main/java/nextstep/payments/ui/new_card/NewCardScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/new_card/NewCardScreen.kt
@@ -21,6 +21,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
@@ -129,8 +131,13 @@ fun NewCardScreen(
                 visualTransformation = CardNumberTransformation(),
                 label = { Text(stringResource(R.string.card_number_label)) },
                 placeholder = { Text(stringResource(R.string.card_number_placeholder)) },
-                modifier = Modifier.fillMaxWidth(),
-            )
+                modifier = Modifier
+                    .semantics {
+                        contentDescription = "카드 번호 입력"
+                    }
+                    .fillMaxWidth(),
+
+                )
 
             OutlinedTextField(
                 value = state.expiredDate,
@@ -144,7 +151,11 @@ fun NewCardScreen(
                 visualTransformation = CardExpiryTransformation(),
                 label = { Text(stringResource(R.string.expired_date_label)) },
                 placeholder = { Text(stringResource(R.string.expired_date_placeholder)) },
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .semantics {
+                        contentDescription = "만료일 입력"
+                    }
+                    .fillMaxWidth(),
             )
 
             OutlinedTextField(
@@ -157,7 +168,11 @@ fun NewCardScreen(
                 ),
                 label = { Text(stringResource(R.string.owner_name_label)) },
                 placeholder = { Text(stringResource(R.string.owner_name_placeholder)) },
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .semantics {
+                        contentDescription = "카드 소유자 이름 입력"
+                    }
+                    .fillMaxWidth(),
             )
 
             OutlinedTextField(
@@ -171,7 +186,11 @@ fun NewCardScreen(
                 ),
                 label = { Text(stringResource(R.string.password_label)) },
                 placeholder = { Text(stringResource(R.string.password_placeholder)) },
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .semantics {
+                        contentDescription = "카드 비밀번호 입력"
+                    }
+                    .fillMaxWidth(),
                 visualTransformation = PasswordVisualTransformation(),
             )
         }

--- a/app/src/main/java/nextstep/payments/ui/new_card/NewCardScreen.kt
+++ b/app/src/main/java/nextstep/payments/ui/new_card/NewCardScreen.kt
@@ -1,5 +1,6 @@
 package nextstep.payments.ui.new_card
 
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -19,6 +20,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
@@ -42,10 +44,19 @@ fun NewCardScreenRoot(
 ) {
     val state by viewModel.cardState.collectAsStateWithLifecycle()
 
+    // Q. ObserveAsEvents block은 composable block이 아니기 때문에, 여기서 context와 문구를 선언한 후 사용했습니다.
+    // 그런데 이렇게 작성하면 사용되는 장소와 사용하는 장소가 분리되어 적절하지 않다고 생각됩니다.
+    // 어떻게 수정하는 것이 좋을지 궁금합니다.
+    val context = LocalContext.current
+    val cardAddFailMessage = stringResource(R.string.card_list_add_new_card_fail)
+
     ObserveAsEvents(viewModel.events) { event ->
         when (event) {
-            NewCardEvent.CardAdded -> {
+            NewCardEvent.CardAddSuccess -> {
                 navigateToCardList()
+            }
+            NewCardEvent.CardAddFail -> {
+                Toast.makeText(context, cardAddFailMessage, Toast.LENGTH_SHORT).show()
             }
             NewCardEvent.NavigateBack -> {
                 navigateToCardList()

--- a/app/src/main/java/nextstep/payments/ui/new_card/NewCardState.kt
+++ b/app/src/main/java/nextstep/payments/ui/new_card/NewCardState.kt
@@ -1,10 +1,8 @@
 package nextstep.payments.ui.new_card
 
-import androidx.compose.ui.text.input.TextFieldValue
-
 data class NewCardState(
-    val cardNumber: TextFieldValue = TextFieldValue(),
-    val expiredDate: TextFieldValue = TextFieldValue(),
+    val cardNumber: String = "",
+    val expiredDate: String = "",
     val ownerName: String = "",
     val password: String = "",
 )

--- a/app/src/main/java/nextstep/payments/ui/new_card/NewCardState.kt
+++ b/app/src/main/java/nextstep/payments/ui/new_card/NewCardState.kt
@@ -5,4 +5,11 @@ data class NewCardState(
     val expiredDate: String = "",
     val ownerName: String = "",
     val password: String = "",
-)
+) {
+    fun isValid(cardInputValidator: CardInputValidator): Boolean {
+        return cardInputValidator.isCardNumberValid(cardNumber) &&
+                cardInputValidator.isExpiredDateValid(expiredDate) &&
+                cardInputValidator.isCardOwnerNameValid(ownerName) &&
+                cardInputValidator.isPasswordValid(password)
+    }
+}

--- a/app/src/main/java/nextstep/payments/ui/new_card/NewCardTopBar.kt
+++ b/app/src/main/java/nextstep/payments/ui/new_card/NewCardTopBar.kt
@@ -12,6 +12,8 @@ import androidx.compose.material3.TopAppBarDefaults.topAppBarColors
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -34,7 +36,10 @@ fun NewCardTopBar(
         actions = {
             IconButton(
                 onClick = { onSaveClick() },
-                enabled = isAddEnabled
+                enabled = isAddEnabled,
+                modifier = Modifier.semantics {
+                    contentDescription = "카드 추가 버튼"
+                }
             ) {
                 Icon(
                     imageVector = Icons.Filled.Check,

--- a/app/src/main/java/nextstep/payments/ui/new_card/NewCardTopBar.kt
+++ b/app/src/main/java/nextstep/payments/ui/new_card/NewCardTopBar.kt
@@ -8,8 +8,10 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -40,6 +42,9 @@ fun NewCardTopBar(
                 )
             }
         },
+        colors = TopAppBarDefaults.topAppBarColors().copy(
+            containerColor = Color.White,
+        ),
         modifier = modifier
     )
 }

--- a/app/src/main/java/nextstep/payments/ui/new_card/NewCardTopBar.kt
+++ b/app/src/main/java/nextstep/payments/ui/new_card/NewCardTopBar.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.Modifier
 fun NewCardTopBar(
     onBackClick: () -> Unit,
     onSaveClick: () -> Unit,
+    isAddEnabled: Boolean,
     modifier: Modifier = Modifier,
 ) {
     TopAppBar(
@@ -29,7 +30,10 @@ fun NewCardTopBar(
             }
         },
         actions = {
-            IconButton(onClick = { onSaveClick() }) {
+            IconButton(
+                onClick = { onSaveClick() },
+                enabled = isAddEnabled
+            ) {
                 Icon(
                     imageVector = Icons.Filled.Check,
                     contentDescription = "완료",

--- a/app/src/main/java/nextstep/payments/ui/new_card/NewCardTopBar.kt
+++ b/app/src/main/java/nextstep/payments/ui/new_card/NewCardTopBar.kt
@@ -8,7 +8,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.TopAppBarDefaults.topAppBarColors
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -42,7 +42,7 @@ fun NewCardTopBar(
                 )
             }
         },
-        colors = TopAppBarDefaults.topAppBarColors().copy(
+        colors = topAppBarColors(
             containerColor = Color.White,
         ),
         modifier = modifier

--- a/app/src/main/java/nextstep/payments/ui/new_card/NewCardViewModel.kt
+++ b/app/src/main/java/nextstep/payments/ui/new_card/NewCardViewModel.kt
@@ -1,7 +1,5 @@
 package nextstep.payments.ui.new_card
 
-import androidx.compose.ui.text.TextRange
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.channels.Channel
@@ -37,43 +35,23 @@ class NewCardViewModel : ViewModel() {
         }
     }
 
-    private fun setCardNumber(cardNumber: TextFieldValue) {
-        val digits = cardNumber.text.filter { it.isDigit() }
+    private fun setCardNumber(cardNumber: String) {
+        val digits = cardNumber.filter { it.isDigit() }
 
         // 최대 길이를 초과한 입력은 무시
         if (digits.length > CARD_NUMBER_MAX_LENGTH) {
             return
         }
 
-        val formatted = buildString {
-            for ((i, digit) in digits.withIndex()) {
-                if (i != 0 && i % 4 == 0) {
-                    append('-')
-                }
-                append(digit)
-            }
-        }
-
-        // 커서 보정
-        val digitsBeforeCursor = cardNumber.text
-            .take(cardNumber.selection.end.coerceIn(0, cardNumber.text.length))
-            .count { it.isDigit() }
-            .coerceAtMost(digits.length)
-
-        val newCursor = digitsBeforeCursor + (digitsBeforeCursor / 4)
-
         _cardState.update {
             it.copy(
-                cardNumber = TextFieldValue(
-                    text = formatted,
-                    selection = TextRange(newCursor)
-                )
+                cardNumber = digits
             )
         }
     }
 
-    private fun setExpiredDate(expiredDate: TextFieldValue) {
-        val digits = expiredDate.text.filter { it.isDigit() }
+    private fun setExpiredDate(expiredDate: String) {
+        val digits = expiredDate.filter { it.isDigit() }
 
         // 최대 길이를 초과한 입력은 무시
         if (digits.length > CARD_EXPIRED_DATE_MAX_LENGTH) {
@@ -92,25 +70,9 @@ class NewCardViewModel : ViewModel() {
             }
         }
 
-        val formatted = when {
-            digits.length <= 2 -> digits
-            else -> digits.substring(0, 2) + "/" + digits.substring(2)
-        }
-
-        // 커서 보정
-        val digitsBeforeCursor = expiredDate.text
-            .take(expiredDate.selection.end.coerceIn(0, expiredDate.text.length))
-            .count { it.isDigit() }
-            .coerceAtMost(digits.length)
-
-        val newCursor = digitsBeforeCursor + (digitsBeforeCursor / 2)
-
         _cardState.update {
             it.copy(
-                expiredDate = TextFieldValue(
-                    text = formatted,
-                    selection = TextRange(newCursor)
-                )
+                expiredDate = digits,
             )
         }
     }
@@ -136,8 +98,8 @@ class NewCardViewModel : ViewModel() {
 
     // isAddEnabled 조건을 통해 입력 값이 올바른지 검증하기는 했으나, 여기서 한 번 더 입력 조건이 올바른지 학인하도록 했습니다.
     private fun addCard() {
-        if (CardInputValidator.isCardNumberValid(_cardState.value.cardNumber.text) &&
-            CardInputValidator.isExpiredDateValid(_cardState.value.expiredDate.text) &&
+        if (CardInputValidator.isCardNumberValid(_cardState.value.cardNumber) &&
+            CardInputValidator.isExpiredDateValid(_cardState.value.expiredDate) &&
             CardInputValidator.isCardOwnerNameValid(_cardState.value.ownerName) &&
             CardInputValidator.isPasswordValid(_cardState.value.password)
         ) {

--- a/app/src/main/java/nextstep/payments/ui/new_card/NewCardViewModel.kt
+++ b/app/src/main/java/nextstep/payments/ui/new_card/NewCardViewModel.kt
@@ -3,14 +3,19 @@ package nextstep.payments.ui.new_card
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 
 class NewCardViewModel : ViewModel() {
 
     private val _cardState = MutableStateFlow(NewCardState())
     val cardState = _cardState.asStateFlow()
+
+    private val eventChannel = Channel<NewCardEvent> { }
+    val events = eventChannel.receiveAsFlow()
 
     fun onAction(action: NewCardAction) {
         when (action) {

--- a/app/src/main/java/nextstep/payments/ui/new_card/NewCardViewModel.kt
+++ b/app/src/main/java/nextstep/payments/ui/new_card/NewCardViewModel.kt
@@ -107,7 +107,7 @@ class NewCardViewModel(
             CardInputValidator.isCardOwnerNameValid(_cardState.value.ownerName) &&
             CardInputValidator.isPasswordValid(_cardState.value.password)
         ) {
-            cardRepository.addCard(
+            val isSuccess = cardRepository.addCard(
                 CardEntity(
                     cardNumber = _cardState.value.cardNumber,
                     expiredDate = _cardState.value.expiredDate,
@@ -116,8 +116,14 @@ class NewCardViewModel(
                 )
             )
 
+            val event = if (isSuccess) {
+                NewCardEvent.CardAddSuccess
+            } else {
+                NewCardEvent.CardAddFail
+            }
+
             viewModelScope.launch {
-                eventChannel.send(NewCardEvent.CardAdded)
+                eventChannel.send(event)
             }
         }
     }

--- a/app/src/main/java/nextstep/payments/ui/new_card/NewCardViewModel.kt
+++ b/app/src/main/java/nextstep/payments/ui/new_card/NewCardViewModel.kt
@@ -3,11 +3,13 @@ package nextstep.payments.ui.new_card
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 
 class NewCardViewModel : ViewModel() {
 
@@ -23,11 +25,20 @@ class NewCardViewModel : ViewModel() {
             is NewCardAction.OnExpiredDateChange -> setExpiredDate(action.expiredDate)
             is NewCardAction.OnOwnerNameChange -> setOwnerName(action.ownerName)
             is NewCardAction.OnPasswordChange -> setPassword(action.password)
+            NewCardAction.OnAddCardClick -> addCard()
+            NewCardAction.OnBackClick -> {
+                // 현재 상황에서는 이러한 로직이 불필요해 보이지만, eventChannel이 꽉차서 send에 실패할 경우 재시도할 수 있도록 trySend 대신 send를 이용했습니다.
+                // 하지만 trySend 대신 send를 이용할 경우 coroutineScope이 필요합니다.
+                // 현재 필요하지 않은 상황을 가정하며 이렇게 코드를 작성하는 것은 오버 엔지니어링인지, 방어적인 코드 작성인지 궁금합니다.
+                viewModelScope.launch {
+                    eventChannel.send(NewCardEvent.NavigateBack)
+                }
+            }
         }
     }
 
     private fun setCardNumber(cardNumber: TextFieldValue) {
-        if (cardNumber.text.length > CARD_NUMBER_MAX_LENGTH || cardNumber.text.lastOrNull()
+        if (cardNumber.text.length > CardInputValidator.CARD_NUMBER_MAX_LENGTH || cardNumber.text.lastOrNull()
                 ?.isDigit() == false
         ) {
             return
@@ -36,7 +47,7 @@ class NewCardViewModel : ViewModel() {
             if (shouldAddSignAtCardNumber(
                     it.cardNumber.text,
                     cardNumber.text
-                ) && cardNumber.text.length != CARD_NUMBER_MAX_LENGTH
+                ) && cardNumber.text.length != CardInputValidator.CARD_NUMBER_MAX_LENGTH
             ) {
                 val newText = "${cardNumber.text}-"
                 it.copy(
@@ -57,8 +68,8 @@ class NewCardViewModel : ViewModel() {
 
 
     private fun setExpiredDate(expiredDate: TextFieldValue) {
-        if (expiredDate.text.length > CARD_EXPIRED_DATE_MAX_LENGTH || expiredDate.text.lastOrNull()
-                ?.isDigit() == false
+        if (expiredDate.text.length > CardInputValidator.CARD_EXPIRED_DATE_MAX_LENGTH
+            || expiredDate.text.lastOrNull()?.isDigit() == false
         ) {
             return
         }
@@ -82,17 +93,16 @@ class NewCardViewModel : ViewModel() {
     }
 
     private fun setOwnerName(ownerName: String) {
-        if (ownerName.length > CARD_OWNER_NAME_MAX_LENGTH) {
-            return
-        }
-        _cardState.update {
-            it.copy(ownerName = ownerName)
+        if (CardInputValidator.isCardOwnerNameValid(ownerName)) {
+            _cardState.update {
+                it.copy(ownerName = ownerName)
+            }
         }
     }
 
     private fun setPassword(password: String) {
-        if (password.length > CARD_PASSWORD_MAX_LENGTH || password.lastOrNull()
-                ?.isDigit() == false
+        if (password.length > CardInputValidator.CARD_PASSWORD_MAX_LENGTH
+            || password.lastOrNull()?.isDigit() == false
         ) {
             return
         }
@@ -101,10 +111,18 @@ class NewCardViewModel : ViewModel() {
         }
     }
 
-    companion object {
-        private const val CARD_NUMBER_MAX_LENGTH = 19
-        private const val CARD_EXPIRED_DATE_MAX_LENGTH = 5
-        private const val CARD_OWNER_NAME_MAX_LENGTH = 30
-        private const val CARD_PASSWORD_MAX_LENGTH = 4
+    // isAddEnabled 조건을 통해 입력 값이 올바른지 검증하기는 했으나, 여기서 한 번 더 입력 조건이 올바른지 학인하도록 했습니다.
+    private fun addCard() {
+        if (CardInputValidator.isCardNumberValid(_cardState.value.cardNumber.text) &&
+            CardInputValidator.isExpiredDateValid(_cardState.value.expiredDate.text) &&
+            CardInputValidator.isCardOwnerNameValid(_cardState.value.ownerName) &&
+            CardInputValidator.isPasswordValid(_cardState.value.password)
+        ) {
+            // TODO : 카드 추가하기
+
+            viewModelScope.launch {
+                eventChannel.send(NewCardEvent.CardAdded)
+            }
+        }
     }
 }

--- a/app/src/main/java/nextstep/payments/ui/new_card/NewCardViewModel.kt
+++ b/app/src/main/java/nextstep/payments/ui/new_card/NewCardViewModel.kt
@@ -38,34 +38,26 @@ class NewCardViewModel : ViewModel() {
     }
 
     private fun setCardNumber(cardNumber: TextFieldValue) {
-        if (cardNumber.text.length > CardInputValidator.CARD_NUMBER_MAX_LENGTH || cardNumber.text.lastOrNull()
-                ?.isDigit() == false
-        ) {
-            return
-        }
-        _cardState.update {
-            if (shouldAddSignAtCardNumber(
-                    it.cardNumber.text,
-                    cardNumber.text
-                ) && cardNumber.text.length != CardInputValidator.CARD_NUMBER_MAX_LENGTH
-            ) {
-                val newText = "${cardNumber.text}-"
-                it.copy(
-                    cardNumber = TextFieldValue(
-                        text = newText,
-                        selection = TextRange(newText.length)
-                    )
-                )
-            } else {
-                it.copy(cardNumber = cardNumber)
+        val digits = cardNumber.text.filter { it.isDigit() }.take(CARD_NUMBER_MAX_LENGTH)
+
+        val formatted = buildString {
+            for ((i, digit) in digits.withIndex()) {
+                if (i != 0 && i % 4 == 0) {
+                    append('-')
+                }
+                append(digit)
             }
         }
-    }
 
-    private fun shouldAddSignAtCardNumber(beforeText: String, afterText: String): Boolean {
-        return beforeText.length % 5 == 3 && afterText.length % 5 == 4
+        _cardState.update {
+            it.copy(
+                cardNumber = TextFieldValue(
+                    text = formatted,
+                    selection = TextRange(formatted.length)
+                )
+            )
+        }
     }
-
 
     private fun setExpiredDate(expiredDate: TextFieldValue) {
         val digits = expiredDate.text.filter { it.isDigit() }.take(4)
@@ -95,10 +87,6 @@ class NewCardViewModel : ViewModel() {
                 )
             )
         }
-    }
-
-    private fun shouldAddSignAtExpiredDate(beforeText: String, afterText: String): Boolean {
-        return beforeText.length == 2 && afterText.length == 3
     }
 
     private fun setOwnerName(ownerName: String) {
@@ -136,6 +124,7 @@ class NewCardViewModel : ViewModel() {
     }
 
     companion object {
+        private const val CARD_NUMBER_MAX_LENGTH = 16
         private val FIRST_MONTH_DIGIT_RANGE = '0'..'1'
         private val MONTH_RANGE = 1..12
     }

--- a/app/src/main/java/nextstep/payments/ui/new_card/NewCardViewModel.kt
+++ b/app/src/main/java/nextstep/payments/ui/new_card/NewCardViewModel.kt
@@ -38,7 +38,12 @@ class NewCardViewModel : ViewModel() {
     }
 
     private fun setCardNumber(cardNumber: TextFieldValue) {
-        val digits = cardNumber.text.filter { it.isDigit() }.take(CARD_NUMBER_MAX_LENGTH)
+        val digits = cardNumber.text.filter { it.isDigit() }
+
+        // 최대 길이를 초과한 입력은 무시
+        if (digits.length > CARD_NUMBER_MAX_LENGTH) {
+            return
+        }
 
         val formatted = buildString {
             for ((i, digit) in digits.withIndex()) {
@@ -68,7 +73,12 @@ class NewCardViewModel : ViewModel() {
     }
 
     private fun setExpiredDate(expiredDate: TextFieldValue) {
-        val digits = expiredDate.text.filter { it.isDigit() }.take(4)
+        val digits = expiredDate.text.filter { it.isDigit() }
+
+        // 최대 길이를 초과한 입력은 무시
+        if (digits.length > CARD_EXPIRED_DATE_MAX_LENGTH) {
+            return
+        }
 
         if (digits.length >= 2) {
             val mm = digits.substring(0, 2).toInt()
@@ -141,6 +151,7 @@ class NewCardViewModel : ViewModel() {
 
     companion object {
         private const val CARD_NUMBER_MAX_LENGTH = 16
+        private const val CARD_EXPIRED_DATE_MAX_LENGTH = 4
         private val FIRST_MONTH_DIGIT_RANGE = '0'..'1'
         private val MONTH_RANGE = 1..12
     }

--- a/app/src/main/java/nextstep/payments/ui/new_card/NewCardViewModel.kt
+++ b/app/src/main/java/nextstep/payments/ui/new_card/NewCardViewModel.kt
@@ -8,8 +8,12 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import nextstep.payments.data.card.CardEntity
+import nextstep.payments.data.card.PaymentCardRepository
 
-class NewCardViewModel : ViewModel() {
+class NewCardViewModel(
+    private val cardRepository: PaymentCardRepository = PaymentCardRepository,
+) : ViewModel() {
 
     private val _cardState = MutableStateFlow(NewCardState())
     val cardState = _cardState.asStateFlow()
@@ -103,7 +107,14 @@ class NewCardViewModel : ViewModel() {
             CardInputValidator.isCardOwnerNameValid(_cardState.value.ownerName) &&
             CardInputValidator.isPasswordValid(_cardState.value.password)
         ) {
-            // TODO : 카드 추가하기
+            cardRepository.addCard(
+                CardEntity(
+                    cardNumber = _cardState.value.cardNumber,
+                    expiredDate = _cardState.value.expiredDate,
+                    ownerName = _cardState.value.ownerName,
+                    password = _cardState.value.password,
+                )
+            )
 
             viewModelScope.launch {
                 eventChannel.send(NewCardEvent.CardAdded)

--- a/app/src/main/java/nextstep/payments/ui/new_card/NewCardViewModel.kt
+++ b/app/src/main/java/nextstep/payments/ui/new_card/NewCardViewModel.kt
@@ -43,7 +43,7 @@ class NewCardViewModel(
         val digits = cardNumber.filter { it.isDigit() }
 
         // 최대 길이를 초과한 입력은 무시
-        if (digits.length > CARD_NUMBER_MAX_LENGTH) {
+        if (digits.length > CardInputValidator.CARD_NUMBER_MAX_LENGTH) {
             return
         }
 
@@ -58,7 +58,7 @@ class NewCardViewModel(
         val digits = expiredDate.filter { it.isDigit() }
 
         // 최대 길이를 초과한 입력은 무시
-        if (digits.length > CARD_EXPIRED_DATE_MAX_LENGTH) {
+        if (digits.length > CardInputValidator.CARD_EXPIRED_DATE_MAX_LENGTH) {
             return
         }
 
@@ -123,8 +123,6 @@ class NewCardViewModel(
     }
 
     companion object {
-        private const val CARD_NUMBER_MAX_LENGTH = 16
-        private const val CARD_EXPIRED_DATE_MAX_LENGTH = 4
         private val FIRST_MONTH_DIGIT_RANGE = '0'..'1'
         private val MONTH_RANGE = 1..12
     }

--- a/app/src/main/java/nextstep/payments/ui/new_card/NewCardViewModel.kt
+++ b/app/src/main/java/nextstep/payments/ui/new_card/NewCardViewModel.kt
@@ -49,11 +49,19 @@ class NewCardViewModel : ViewModel() {
             }
         }
 
+        // 커서 보정
+        val digitsBeforeCursor = cardNumber.text
+            .take(cardNumber.selection.end.coerceIn(0, cardNumber.text.length))
+            .count { it.isDigit() }
+            .coerceAtMost(digits.length)
+
+        val newCursor = digitsBeforeCursor + (digitsBeforeCursor / 4)
+
         _cardState.update {
             it.copy(
                 cardNumber = TextFieldValue(
                     text = formatted,
-                    selection = TextRange(formatted.length)
+                    selection = TextRange(newCursor)
                 )
             )
         }
@@ -79,11 +87,19 @@ class NewCardViewModel : ViewModel() {
             else -> digits.substring(0, 2) + "/" + digits.substring(2)
         }
 
+        // 커서 보정
+        val digitsBeforeCursor = expiredDate.text
+            .take(expiredDate.selection.end.coerceIn(0, expiredDate.text.length))
+            .count { it.isDigit() }
+            .coerceAtMost(digits.length)
+
+        val newCursor = digitsBeforeCursor + (digitsBeforeCursor / 2)
+
         _cardState.update {
             it.copy(
                 expiredDate = TextFieldValue(
                     text = formatted,
-                    selection = TextRange(formatted.length)
+                    selection = TextRange(newCursor)
                 )
             )
         }

--- a/app/src/main/java/nextstep/payments/ui/new_card/NewCardViewModel.kt
+++ b/app/src/main/java/nextstep/payments/ui/new_card/NewCardViewModel.kt
@@ -68,23 +68,32 @@ class NewCardViewModel : ViewModel() {
 
 
     private fun setExpiredDate(expiredDate: TextFieldValue) {
-        if (expiredDate.text.length > CardInputValidator.CARD_EXPIRED_DATE_MAX_LENGTH
-            || expiredDate.text.lastOrNull()?.isDigit() == false
-        ) {
-            return
-        }
-        _cardState.update {
-            if (shouldAddSignAtExpiredDate(it.expiredDate.text, expiredDate.text)) {
-                val newText = "${expiredDate.text.substring(0, 2)}/${expiredDate.text[2]}"
-                it.copy(
-                    expiredDate = TextFieldValue(
-                        text = newText,
-                        selection = TextRange(newText.length)
-                    )
-                )
-            } else {
-                it.copy(expiredDate = expiredDate)
+        val digits = expiredDate.text.filter { it.isDigit() }.take(4)
+
+        if (digits.length >= 2) {
+            val mm = digits.substring(0, 2).toInt()
+            if (mm !in MONTH_RANGE) {
+                return
             }
+        } else if (digits.length == 1) {
+            val first = digits[0]
+            if (first !in FIRST_MONTH_DIGIT_RANGE) {
+                return
+            }
+        }
+
+        val formatted = when {
+            digits.length <= 2 -> digits
+            else -> digits.substring(0, 2) + "/" + digits.substring(2)
+        }
+
+        _cardState.update {
+            it.copy(
+                expiredDate = TextFieldValue(
+                    text = formatted,
+                    selection = TextRange(formatted.length)
+                )
+            )
         }
     }
 
@@ -124,5 +133,10 @@ class NewCardViewModel : ViewModel() {
                 eventChannel.send(NewCardEvent.CardAdded)
             }
         }
+    }
+
+    companion object {
+        private val FIRST_MONTH_DIGIT_RANGE = '0'..'1'
+        private val MONTH_RANGE = 1..12
     }
 }

--- a/app/src/main/java/nextstep/payments/ui/theme/Theme.kt
+++ b/app/src/main/java/nextstep/payments/ui/theme/Theme.kt
@@ -8,7 +8,6 @@ import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 
 private val DarkColorScheme = darkColorScheme(

--- a/app/src/main/java/nextstep/payments/ui/theme/Theme.kt
+++ b/app/src/main/java/nextstep/payments/ui/theme/Theme.kt
@@ -8,6 +8,7 @@ import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 
 private val DarkColorScheme = darkColorScheme(
@@ -19,8 +20,7 @@ private val DarkColorScheme = darkColorScheme(
 private val LightColorScheme = lightColorScheme(
     primary = Purple40,
     secondary = PurpleGrey40,
-    tertiary = Pink40
-
+    tertiary = Pink40,
     /* Other default colors to override
     background = Color(0xFFFFFBFE),
     surface = Color(0xFFFFFBFE),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,4 +8,7 @@
     <string name="password_placeholder">0000</string>
     <string name="owner_name_label">카드 소유자 이름(선택)</string>
     <string name="owner_name_placeholder">카드에 표시된 이름을 입력하세요.</string>
+    <string name="card_list_title">Payments</string>
+    <string name="card_list_add_new_card">새로운 카드를 등록해주세요</string>
+    <string name="card_list_add_new_card_top_bar">추가</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,4 +11,5 @@
     <string name="card_list_title">Payments</string>
     <string name="card_list_add_new_card">새로운 카드를 등록해주세요</string>
     <string name="card_list_add_new_card_top_bar">추가</string>
+    <string name="card_list_add_new_card_fail">카드 등록에 실패했습니다.</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ lifecycleRuntimeKtx = "2.9.2"
 activityCompose = "1.10.1"
 constraintLayoutCompose = "1.1.1"
 composeBom = "2025.08.00"
+material3 = "1.4.0-beta02"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -27,7 +28,7 @@ androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
-androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "material3" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,13 +1,14 @@
 [versions]
-agp = "8.5.2"
-kotlin = "2.1.0"
-coreKtx = "1.15.0"
+agp = "8.11.1"
+kotlin = "2.2.10"
+coreKtx = "1.17.0"
 junit = "4.13.2"
-junitVersion = "1.2.1"
-espressoCore = "3.6.1"
-lifecycleRuntimeKtx = "2.8.7"
-activityCompose = "1.10.0"
-composeBom = "2025.02.00"
+junitVersion = "1.3.0"
+espressoCore = "3.7.0"
+lifecycleRuntimeKtx = "2.9.2"
+activityCompose = "1.10.1"
+constraintLayoutCompose = "1.1.1"
+composeBom = "2025.08.00"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -19,6 +20,7 @@ androidx-activity-compose = { group = "androidx.activity", name = "activity-comp
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycleRuntimeKtx" }
 androidx-lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "lifecycleRuntimeKtx" }
+androidx-constraintlayout-compose = { group = "androidx.constraintlayout", name = "constraintlayout-compose", version.ref = "constraintLayoutCompose" }
 androidx-ui = { group = "androidx.compose.ui", name = "ui" }
 androidx-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
 androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ activityCompose = "1.10.1"
 constraintLayoutCompose = "1.1.1"
 composeBom = "2025.08.00"
 material3 = "1.4.0-beta02"
+materialIconsExtended = "1.7.8"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -29,6 +30,7 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "material3" }
+androidx-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended", version.ref = "materialIconsExtended" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## 많이 고민한 내용

### 카드 입력 검증

카드 추가 화면에서 사용자가 입력한 값이 올바른지 검증하는 로직에서 최대한 edge case를 대응하려고 했습니다.(사용자가 커서를 중간에 둬서 값을 수정하면 올바른 값이 아니게 되는 경우, 예를 들어 만료일로 1271가 입력되었을 때, 2를 지우는 경우 방지) 사용자가 입력한 값을 검증하고, state에 저장하는 현재의 구조에 대해 피드백 받고 싶습니다.


### PaymentCard

카드 번호가 Chip 하단 8dp에 위치해야 한다는 요구 조건을 만족하기 위해 ConstraintLayout을 사용했습니다. ConstraintLayout을 안 쓰기 위해, Box modifier만을 이용해서 `Chip 하단 8dp에 위치`를 구현하는 방법을 찾아봤지만 없었습니다. Custom Layout을 이용해서 구현해보려고 관련 Phillip 강의를 봤는데, 강의를 다 보고 나니 Custom Layout을 이용해 구현하는 것이 더 복잡하고, 나중에 요구사항이 변경되었을 때 대응이 힘들다는 것을 알았습니다. 그래서 ConstraintLayout을 이용했습니다.

[Compound Component 패턴](https://wisemuji.medium.com/jetpack-compose-ui-%EC%A1%B0%ED%95%A9-composition-%ED%95%98%EA%B8%B0-%EC%8B%AC%ED%99%94-33910e8f09df)을 사용할 수 있을지 고민해보기 위해 ConstraintLayout을 안 써보려고 고민했습니다. ConstraintLayout 사용 여부와 무관하게, 여전히 Slot 패턴 대신 Compound Component 패턴을 왜 써야 하는지를 이해하지 못했습니다. 😅

ConstraintLayout을 써보니, xml로 구현할 때처럼 UI의 배치가 자유로워서 좋았습니다. 그런데 ConstraintLayout을 쓰는 경우를 보지 못했는데, 지훈 님은 어떨 때 쓰시는지 궁금합니다. 안 쓰신다면 왜 안 쓰시는지 궁금해요. 저는 xml에서 compose로 넘어올 때, ConstraintLayout이 있는 것을 보고 xml에서 작성하던 패턴 그대로 ConstraintLayout을 써야겠다고 생각했었습니다. 그런데 공식 문서나 강의에서 Row, Column을 사용하더라도 성능 상의 문제가 없다고 설명하며 ConstraintLayout을 안 쓰기에 저도 안 썼습니다.

<img width="993" height="615" alt="image" src="https://github.com/user-attachments/assets/d3cf6ffa-43d2-47d8-a9a8-08cd1899af0f" />


## 테스트 코드

테스트 코드까지 작성하면 리뷰 요청 시점이 더 멀어질 것 같아서, 테스트 코드 외 부분을 구현하고 리뷰 요청 드렸습니다. 리뷰를 기다리면서 테스트 코드를 작성하고, 남겨주신 코멘트도 반영하겠습니다.